### PR TITLE
fix: preserve builtin AList site during remote sync

### DIFF
--- a/src/main/java/cn/har01d/alist_tvbox/service/SiteService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/SiteService.java
@@ -72,32 +72,50 @@ public class SiteService {
     @PostConstruct
     public void init() {
         if (siteRepository.count() > 0) {
-            siteRepository.findById(1).ifPresent(this::updateSite);
+            siteRepository.findById(1).ifPresentOrElse(this::updateSite, this::restoreDefaultSite);
             fixId();
             return;
         }
 
         int order = 1;
         for (cn.har01d.alist_tvbox.tvbox.Site s : appProperties.getSites()) {
-            Site site = new Site();
-            site.setName(s.getName());
-            site.setUrl(s.getUrl());
-            site.setPassword(s.getPassword());
-            site.setSearchable(s.isSearchable());
-            site.setXiaoya(s.isXiaoya());
-            site.setIndexFile(s.getIndexFile());
-            site.setVersion(s.getVersion());
+            Site site = createSite(s, order);
             if (order == 1) {
                 aListToken = generateToken();
                 site.setToken(aListToken);
                 aListLocalService.executeUpdate("UPDATE x_setting_items SET value='" + aListToken + "' WHERE key='token'");
             }
-            site.setOrder(order++);
             siteRepository.save(site);
             log.info("save site to database: {}", site);
+            order++;
         }
 
         readAList(order);
+    }
+
+    private void restoreDefaultSite() {
+        if (appProperties.getSites() == null || appProperties.getSites().isEmpty()) {
+            log.warn("default site config is empty, skip restoring site id 1");
+            return;
+        }
+
+        Site site = createSite(appProperties.getSites().getFirst(), 1);
+        site.setId(1);
+        updateSite(site);
+        log.warn("restore default site id 1: {}", site);
+    }
+
+    private Site createSite(cn.har01d.alist_tvbox.tvbox.Site s, int order) {
+        Site site = new Site();
+        site.setName(s.getName());
+        site.setUrl(s.getUrl());
+        site.setPassword(s.getPassword());
+        site.setSearchable(s.isSearchable());
+        site.setXiaoya(s.isXiaoya());
+        site.setIndexFile(s.getIndexFile());
+        site.setVersion(s.getVersion());
+        site.setOrder(order);
+        return site;
     }
 
     private void fixId() {

--- a/src/main/java/cn/har01d/alist_tvbox/service/sync/SyncService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/sync/SyncService.java
@@ -15,6 +15,8 @@ import java.util.*;
 @Slf4j
 @Service
 public class SyncService {
+    private static final Integer BUILTIN_ALIST_SITE_ID = 1;
+
     private final SettingRepository settingRepository;
     private final SiteRepository siteRepository;
     private final ShareRepository shareRepository;
@@ -277,15 +279,27 @@ public class SyncService {
 
         try {
             if (strategy == MergeStrategy.OVERWRITE) {
-                siteRepository.deleteAll();
+                List<Site> localSites = siteRepository.findAll();
+                List<Site> deletableSites = localSites.stream()
+                        .filter(site -> !isBuiltInAListSite(site))
+                        .toList();
+                siteRepository.deleteAll(deletableSites);
             }
 
             for (Site remote : sites) {
                 try {
+                    if (isBuiltInAListSite(remote)) {
+                        continue;
+                    }
+
                     Optional<Site> existing = siteRepository.findByUrl(remote.getUrl());
                     if (existing.isPresent()) {
                         // 更新：保留本地 ID
                         Site local = existing.get();
+                        if (isBuiltInAListSite(local)) {
+                            continue;
+                        }
+
                         local.setName(remote.getName());
                         local.setPassword(remote.getPassword());
                         local.setToken(remote.getToken());
@@ -320,6 +334,10 @@ public class SyncService {
         }
 
         return result;
+    }
+
+    private boolean isBuiltInAListSite(Site site) {
+        return site != null && Objects.equals(site.getId(), BUILTIN_ALIST_SITE_ID);
     }
 
     // 占位方法，将在后续任务实现

--- a/src/test/java/cn/har01d/alist_tvbox/service/SiteServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/SiteServiceTest.java
@@ -1,0 +1,70 @@
+package cn.har01d.alist_tvbox.service;
+
+import cn.har01d.alist_tvbox.config.AppProperties;
+import cn.har01d.alist_tvbox.entity.Setting;
+import cn.har01d.alist_tvbox.entity.SettingRepository;
+import cn.har01d.alist_tvbox.entity.Site;
+import cn.har01d.alist_tvbox.entity.SiteRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SiteServiceTest {
+    @Mock
+    private SiteRepository siteRepository;
+    @Mock
+    private SettingRepository settingRepository;
+    @Mock
+    private AListLocalService aListLocalService;
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private JdbcTemplate alistJdbcTemplate;
+
+    @Test
+    void initShouldRestoreBuiltInAListSiteWhenIdOneIsMissing() {
+        AppProperties appProperties = new AppProperties();
+        cn.har01d.alist_tvbox.tvbox.Site configured = new cn.har01d.alist_tvbox.tvbox.Site();
+        configured.setName("本地");
+        configured.setUrl("http://localhost");
+        configured.setVersion(3);
+        configured.setSearchable(true);
+        appProperties.setSites(List.of(configured));
+
+        when(siteRepository.count()).thenReturn(1L);
+        when(siteRepository.findById(1)).thenReturn(Optional.empty());
+        when(settingRepository.findById("fix_site_id")).thenReturn(Optional.of(new Setting("fix_site_id", "true")));
+
+        SiteService service = new SiteService(
+                appProperties,
+                siteRepository,
+                settingRepository,
+                aListLocalService,
+                jdbcTemplate,
+                new RestTemplateBuilder(),
+                alistJdbcTemplate
+        );
+
+        service.init();
+
+        verify(siteRepository).save(argThat(site ->
+                Integer.valueOf(1).equals(site.getId())
+                        && "本地".equals(site.getName())
+                        && "http://localhost".equals(site.getUrl())
+                        && site.isSearchable()
+                        && Integer.valueOf(3).equals(site.getVersion())
+                        && site.getToken() != null
+                        && site.getToken().startsWith("openlist-")));
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/service/sync/SyncServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/sync/SyncServiceTest.java
@@ -44,6 +44,12 @@ class SyncServiceTest {
     @Mock
     private PluginFilterRepository pluginFilterRepository;
     @Mock
+    private JellyfinRepository jellyfinRepository;
+    @Mock
+    private EmbyRepository embyRepository;
+    @Mock
+    private FeiniuRepository feiniuRepository;
+    @Mock
     private RemoteClient remoteClient;
     @Mock
     private cn.har01d.alist_tvbox.service.UserService userService;
@@ -248,5 +254,56 @@ class SyncServiceTest {
         assertEquals(1, settings.size());  // 只有一个 key
         assertTrue(settings.containsKey("bilibili_cookie"));
         assertEquals("test_cookie", settings.get("bilibili_cookie"));
+    }
+
+    @Test
+    void testImportSites_OverwritePreservesBuiltInAListSite() {
+        // Given
+        Site builtIn = site(1, "AList", "http://127.0.0.1:5244");
+        Site oldSite = site(2, "Old", "http://old.example.com");
+        Site remoteBuiltIn = site(1, "Remote AList", "http://127.0.0.1:5244");
+        Site remoteSite = site(9, "Remote", "http://remote.example.com");
+
+        when(siteRepository.findAll()).thenReturn(List.of(builtIn, oldSite));
+        when(siteRepository.findByUrl(remoteSite.getUrl())).thenReturn(Optional.empty());
+        when(siteRepository.save(any(Site.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        SyncResult result = syncService.importSites(List.of(remoteBuiltIn, remoteSite), MergeStrategy.OVERWRITE);
+
+        // Then
+        verify(siteRepository, never()).deleteAll();
+        verify(siteRepository).deleteAll(List.of(oldSite));
+        verify(siteRepository, never()).findByUrl(remoteBuiltIn.getUrl());
+        assertEquals(1, result.getImported());
+        assertEquals(0, result.getUpdated());
+        assertEquals(0, result.getFailed());
+    }
+
+    @Test
+    void testImportSites_DoesNotUpdateLocalBuiltInAListSiteMatchedByUrl() {
+        // Given
+        Site builtIn = site(1, "AList", "http://127.0.0.1:5244");
+        Site remote = site(9, "Remote AList", "http://127.0.0.1:5244");
+
+        when(siteRepository.findByUrl(remote.getUrl())).thenReturn(Optional.of(builtIn));
+
+        // When
+        SyncResult result = syncService.importSites(List.of(remote), MergeStrategy.MERGE);
+
+        // Then
+        verify(siteRepository, never()).save(any(Site.class));
+        assertEquals("AList", builtIn.getName());
+        assertEquals(0, result.getImported());
+        assertEquals(0, result.getUpdated());
+        assertEquals(0, result.getFailed());
+    }
+
+    private Site site(Integer id, String name, String url) {
+        Site site = new Site();
+        site.setId(id);
+        site.setName(name);
+        site.setUrl(url);
+        return site;
     }
 }


### PR DESCRIPTION
## Summary
- Preserve the built-in AList site (id=1) during remote config site overwrite imports.
- Skip importing or updating id=1 from sync payloads so the local built-in site remains authoritative.
- Restore the built-in site on startup if id=1 was previously deleted while other sites still exist.

## Test Plan
- mvn test
- git diff --check