### PR TITLE
fix: insert missing builtin site on startup

### DIFF
--- a/src/main/java/cn/har01d/alist_tvbox/service/SiteService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/SiteService.java
@@ -101,8 +101,32 @@ public class SiteService {
 
         Site site = createSite(appProperties.getSites().getFirst(), 1);
         site.setId(1);
-        updateSite(site);
+        aListToken = generateToken();
+        site.setToken(aListToken);
+        insertDefaultSite(site);
+        settingRepository.save(new Setting("alist_token", aListToken));
+        aListLocalService.setSetting("token", aListToken, "string");
         log.warn("restore default site id 1: {}", site);
+    }
+
+    private void insertDefaultSite(Site site) {
+        jdbcTemplate.update("""
+                INSERT INTO site
+                (id, name, url, password, token, index_file, folder, searchable, disabled, xiaoya, `order`, `version`)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                site.getId(),
+                site.getName(),
+                site.getUrl(),
+                site.getPassword(),
+                site.getToken(),
+                site.getIndexFile(),
+                site.getFolder(),
+                site.isSearchable(),
+                site.isDisabled(),
+                site.isXiaoya(),
+                site.getOrder(),
+                site.getVersion());
     }
 
     private Site createSite(cn.har01d.alist_tvbox.tvbox.Site s, int order) {

--- a/src/test/java/cn/har01d/alist_tvbox/service/SiteServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/SiteServiceTest.java
@@ -15,7 +15,10 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -58,13 +61,23 @@ class SiteServiceTest {
 
         service.init();
 
-        verify(siteRepository).save(argThat(site ->
-                Integer.valueOf(1).equals(site.getId())
-                        && "本地".equals(site.getName())
-                        && "http://localhost".equals(site.getUrl())
-                        && site.isSearchable()
-                        && Integer.valueOf(3).equals(site.getVersion())
-                        && site.getToken() != null
-                        && site.getToken().startsWith("openlist-")));
+        verify(siteRepository, never()).save(any(Site.class));
+        verify(jdbcTemplate).update(
+                startsWith("INSERT INTO site"),
+                eq(1),
+                eq("本地"),
+                eq("http://localhost"),
+                eq(""),
+                startsWith("openlist-"),
+                eq(null),
+                eq(""),
+                eq(true),
+                eq(false),
+                eq(false),
+                eq(1),
+                eq(3)
+        );
+        verify(settingRepository).save(any(Setting.class));
+        verify(aListLocalService).setSetting(eq("token"), startsWith("openlist-"), eq("string"));
     }
 }


### PR DESCRIPTION
## Summary
- Avoid restoring missing site id=1 through JPA save, which treats the manual id as a detached entity and can fail startup with StaleObjectStateException.
- Insert the missing built-in AList site with JDBC during startup recovery.
- Keep AList token synchronization by saving alist_token and updating the embedded AList token setting.

## Test Plan
- mvn test
- git diff --check