### PR TITLE
feat: support raw Python backend parsing

### DIFF
--- a/docs/superpowers/plans/2026-07-19-raw-python-backend-parse.md
+++ b/docs/superpowers/plans/2026-07-19-raw-python-backend-parse.md
@@ -105,7 +105,7 @@ from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from unittest.mock import Mock, patch
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 MODULE = SourceFileLoader("atvp_raw_backend_parse", str(ROOT / "main/resources/static/Atvp.py")).load_module()
 Spider = MODULE.Spider
 

--- a/docs/superpowers/plans/2026-07-19-raw-python-backend-parse.md
+++ b/docs/superpowers/plans/2026-07-19-raw-python-backend-parse.md
@@ -1,0 +1,297 @@
+# Raw Python backend_parse Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run raw `.py` subscription plugins through `Atvp.py` so `self.backend_parse = True` gets the same directory, detail, backend parse, and backend play behavior as encrypted `.txt` plugins.
+
+**Architecture:** Keep the backend cache and authenticated `.py` endpoint unchanged. Change raw Python ext to load `Atvp.py` as the PyProxy delegate, provide the raw `.py` file as `source`, and mark it with `raw: true`; Atvp skips only secspider decryption for that payload and then reuses its existing backend-parse runtime. Add Java protocol tests and standard-library Python behavior tests.
+
+**Tech Stack:** Java 21, Spring Boot 4, JUnit 5, Mockito, AssertJ, Python 3 `unittest`, `unittest.mock`, requests, PyCryptodome, lxml.
+
+---
+
+## File Map
+
+- Modify `src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java`: assert raw Python ext uses Atvp loader, `.py` source, and `raw: true` in both run modes.
+- Modify `src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java`: build raw Python payload with Atvp loader and raw source marker.
+- Modify `src/test/python/test_Atvp_raw_backend_parse.py`: create raw ext fixtures, prove decryption is skipped, and exercise `backend_parse=True` category/detail/parse/play behavior.
+- Modify `src/main/resources/static/Atvp.py`: add an explicit raw payload predicate and bypass only the encrypted package decryptor for raw sources.
+
+### Task 1: Lock the raw Python subscription protocol
+
+**Files:**
+- Modify: `src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java`
+- Modify: `src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java`
+
+- [ ] **Step 1: Write the failing Java protocol assertions**
+
+In `rawPythonPluginShouldUsePyProxyLoaderAndLocalProxyInEveryRunMode`, replace the current raw payload assertions with:
+
+```java
+assertThat(payload)
+        .containsEntry("loader", "http://atv/Atvp.py")
+        .containsEntry("source", "http://atv/plugins/web/7.py")
+        .containsEntry("raw", true)
+        .containsEntry("api", "http://atv")
+        .containsEntry("token", "vod-token")
+        .containsEntry("secret", "secret")
+        .containsEntry("data", "{\"site\":\"demo\"}")
+        .containsEntry("local_proxy_config", localProxyConfig);
+```
+
+Also assert the raw payload has no direct loader to the plugin file:
+
+```java
+assertThat(payload.get("loader")).isNotEqualTo("http://atv/plugins/web/7.py");
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+mvn -q -Dtest=SubscriptionServiceTest#rawPythonPluginShouldUsePyProxyLoaderAndLocalProxyInEveryRunMode test
+```
+
+Expected: failure because the current helper emits `loader=/plugins/web/7.py` and no `source/raw` fields.
+
+- [ ] **Step 3: Implement the Atvp-wrapped raw payload**
+
+In `SubscriptionService.buildPluginExtPayload`, keep the existing `.txt` branch and add the raw branch:
+
+```java
+if (rawPython) {
+    map.put("loader", baseUrl + "/Atvp.py");
+    map.put("source", baseUrl + "/plugins/" + contentToken + "/" + plugin.getId() + ".py");
+    map.put("raw", true);
+} else {
+    map.put("source", baseUrl + "/plugins/" + contentToken + "/" + plugin.getId() + ".txt");
+}
+```
+
+Do not change `selectPluginApi`; raw plugins continue using `csp_PyProxy`. Preserve the existing token, secret, data, and local proxy assignments.
+
+- [ ] **Step 4: Run focused Java tests and verify GREEN**
+
+Run:
+
+```bash
+mvn -q -Dtest=SubscriptionServiceTest test
+```
+
+Expected: all subscription tests pass, including `.txt` Java/native mode regression assertions.
+
+- [ ] **Step 5: Commit the ext protocol change**
+
+```bash
+git add src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java
+git commit -m "feat: wrap raw Python plugins with Atvp"
+```
+
+### Task 2: Add failing Atvp raw-source behavior tests
+
+**Files:**
+- Create: `src/test/python/test_Atvp_raw_backend_parse.py`
+
+- [ ] **Step 1: Create a standard-library unittest fixture**
+
+Create a test module which loads the repository Atvp implementation without pytest:
+
+```python
+import base64
+import json
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = SourceFileLoader("atvp_raw_backend_parse", str(ROOT / "main/resources/static/Atvp.py")).load_module()
+Spider = MODULE.Spider
+
+
+class Response:
+    def __init__(self, status_code=200, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class TestAtvpRawBackendParse(unittest.TestCase):
+    def setUp(self):
+        Spider._instance = None
+        self.spider = Spider()
+
+    def build_ext(self):
+        payload = {
+            "loader": "https://atv.example/Atvp.py",
+            "api": "https://atv.example",
+            "source": "https://atv.example/plugins/demo/7.py",
+            "raw": True,
+            "token": "demo",
+            "local_proxy_config": {},
+        }
+        return base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+
+    def init_inner(self, source):
+        with (
+            patch.object(Spider, "_load_source", return_value=source),
+            patch.object(Spider, "_decrypt_secspider_source", side_effect=AssertionError("raw source must not decrypt")),
+        ):
+            self.spider.init(self.build_ext())
+
+    def test_raw_source_skips_secspider_decryption(self):
+        self.init_inner("class Spider:\n    def init(self, extend=\"\"):\n        return None\n")
+        self.assertIsNotNone(self.spider._inner)
+
+    def test_backend_parse_rewrites_category_and_uses_backend_parse_and_play(self):
+        source = '''
+class Spider:
+    def init(self, extend=""):
+        self.backend_parse = True
+    def categoryContent(self, tid, pg, filter, extend):
+        return {"list": [{"vod_id": "movie-1", "vod_name": "Demo"}], "page": 1}
+    def detailContent(self, ids):
+        return {"list": [{"vod_id": ids[0], "vod_name": "Demo", "vod_play_from": "网盘", "vod_play_url": "网盘$1@share"}]}
+'''
+        self.init_inner(source)
+        home = self.spider.categoryContent("home", "1", False, {})
+        self.assertTrue(home["list"][0]["vod_id"].startswith(self.spider.DETAIL_PREFIX))
+        detail = self.spider.categoryContent(home["list"][0]["vod_id"], "1", False, {})
+        self.assertEqual(detail["list"][0]["vod_id"], "1@share")
+
+        self.spider.post = Mock(return_value=Response(text=json.dumps({"list": [{"vod_id": "share", "vod_name": "Parsed"}]})))
+        parsed = self.spider.detailContent(["https://pan.example/share"])
+        self.assertEqual(parsed["list"][0]["vod_name"], "Parsed")
+        self.spider.fetch = Mock(return_value=Response(text=json.dumps({"parse": 0, "url": "https://video.example/demo.m3u8"})))
+        played = self.spider.playerContent("网盘", "1@share", [])
+        self.assertEqual(played["url"], "https://video.example/demo.m3u8")
+        self.spider.post.assert_called_once()
+        self.spider.fetch.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+The fixture deliberately makes `_decrypt_secspider_source` fail if invoked and asserts the existing `backend_parse` transformations, so the test fails before the raw branch exists.
+
+- [ ] **Step 2: Run the Python tests and verify RED**
+
+Run:
+
+```bash
+python -m unittest discover -s src/test/python -p 'test_Atvp_raw_backend_parse.py' -v
+```
+
+Expected: the module fails during `init` because current Atvp always calls `_decrypt_secspider_source`.
+
+### Task 3: Implement raw source handling in Atvp.py
+
+**Files:**
+- Modify: `src/main/resources/static/Atvp.py`
+- Modify: `src/test/python/test_Atvp_raw_backend_parse.py`
+
+- [ ] **Step 1: Add an explicit raw payload predicate**
+
+Add this method near `_decode_ext_payload`:
+
+```python
+def _is_raw_source(self, payload):
+    return isinstance(payload, dict) and payload.get("raw") is True
+```
+
+- [ ] **Step 2: Select raw text before the decryptor**
+
+Change `init` from:
+
+```python
+package_text = self._load_source(source)
+source_text = self._decrypt_secspider_source(package_text)
+```
+
+to:
+
+```python
+package_text = self._load_source(source)
+source_text = package_text if self._is_raw_source(payload) else self._decrypt_secspider_source(package_text)
+```
+
+Do not alter `_split_ext`, `_compose_inner_extend`, `_resolve_backend_api`, or any `backend_parse` method.
+
+- [ ] **Step 3: Run Python tests and verify GREEN**
+
+Run:
+
+```bash
+python -m unittest discover -s src/test/python -p 'test_Atvp_raw_backend_parse.py' -v
+```
+
+Expected: both tests pass, including backend `/parse` and `/play` mock calls.
+
+- [ ] **Step 4: Run the existing Atvp Python test suite when available**
+
+The source repository for Atvp tests is `/home/harold/workspace/atv-spiders`. Run:
+
+```bash
+python -m unittest discover -s /home/harold/workspace/atv-spiders/py/tests -p 'test_Atvp.py' -v
+```
+
+Expected: all existing Atvp tests pass; this confirms `.txt` encrypted behavior is unchanged.
+
+- [ ] **Step 5: Commit the raw Atvp runtime**
+
+```bash
+git add src/main/resources/static/Atvp.py src/test/python/test_Atvp_raw_backend_parse.py
+git commit -m "feat: support backend parse for raw Python sources"
+```
+
+### Task 4: Complete verification and review
+
+**Files:**
+- Verify all files changed in Tasks 1-3.
+
+- [ ] **Step 1: Run focused Java and Python tests**
+
+```bash
+mvn -q -Dtest=SubscriptionServiceTest,PluginServiceTest,PluginContentControllerTest test
+python -m unittest discover -s src/test/python -p 'test_Atvp_raw_backend_parse.py' -v
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 2: Run full backend and frontend verification**
+
+```bash
+mvn test -q
+```
+
+From `web-ui/`:
+
+```bash
+npm test
+npm run build
+```
+
+Expected: all commands exit `0`.
+
+- [ ] **Step 3: Review protocol and diff scope**
+
+```bash
+git diff --check master...HEAD
+git status --short --branch
+git diff --stat master...HEAD
+```
+
+Expected: no whitespace errors, no generated files, and changes limited to the Atvp runtime, subscription payload helper/tests, Python behavior test, and plan/spec documents.
+
+- [ ] **Step 4: Confirm protocol manually**
+
+The final assertions must establish:
+
+```text
+raw .py -> api=csp_PyProxy
+raw .py ext.loader=/Atvp.py
+raw .py ext.source=/plugins/{token}/{id}.py
+raw .py ext.raw=true
+.txt -> existing source/decrypt flow with no raw marker
+```

--- a/docs/superpowers/plans/2026-07-19-raw-python-plugin.md
+++ b/docs/superpowers/plans/2026-07-19-raw-python-plugin.md
@@ -1,0 +1,492 @@
+# Raw Python Subscription Plugin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow subscription source plugins with `.py` URLs to be cached by the backend and loaded through `csp_PyProxy`, without changing encrypted `.txt` plugin behavior.
+
+**Architecture:** Classify plugins from the URL path suffix, serve cached Python content from a token-protected `.py` endpoint, and generate a `loader` entry in the plugin ext payload for raw Python. Keep the existing entity and download lifecycle; extract only the ext payload selection into package-visible pure helpers so the generated protocol can be tested without constructing the large `SubscriptionService` dependency graph.
+
+**Tech Stack:** Java 21, Spring Boot 4 MVC, Jackson, JUnit 5, Mockito, AssertJ, Vue 3, TypeScript, Node test runner.
+
+---
+
+## File Map
+
+- Modify `src/main/java/cn/har01d/alist_tvbox/service/PluginService.java`: classify `.py` URLs using the parsed URI path.
+- Modify `src/test/java/cn/har01d/alist_tvbox/service/PluginServiceTest.java`: prove raw Python download, refresh, naming, and suffix classification behavior.
+- Modify `src/main/java/cn/har01d/alist_tvbox/web/PluginContentController.java`: expose cached content through a token-protected `.py` route.
+- Create `src/test/java/cn/har01d/alist_tvbox/web/PluginContentControllerTest.java`: verify Python response content type, body, authentication order, and rejection behavior.
+- Modify `src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java`: select `loader` versus `source` and preserve `.txt` run-mode behavior.
+- Modify `src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java`: verify raw Python and encrypted text runtime payloads.
+- Modify `web-ui/src/views/SubscriptionsView.vue`: show that the plugin input accepts `.txt` and `.py`.
+- Modify `web-ui/src/views/SubscriptionsView.test.mjs`: protect the input contract.
+
+### Task 1: Classify and cache raw Python plugins
+
+**Files:**
+- Modify: `src/test/java/cn/har01d/alist_tvbox/service/PluginServiceTest.java`
+- Modify: `src/main/java/cn/har01d/alist_tvbox/service/PluginService.java`
+
+- [ ] **Step 1: Write failing service tests**
+
+Add tests which exercise the existing create/refresh lifecycle and call the not-yet-implemented classifier:
+
+```java
+@Test
+void createShouldStoreRawPythonContentAndClassifyUrlPathWithQuery() {
+    String url = "https://example.com/plugins/Demo.PY?raw=1";
+    String content = "class Spider:\n    pass\n";
+    Plugin plugin = new Plugin();
+    plugin.setUrl(url);
+
+    when(pluginRepository.findByUrl(url)).thenReturn(Optional.empty());
+    when(restTemplate.getForObject(URI.create(url), String.class)).thenReturn(content);
+    when(pluginRepository.save(any(Plugin.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    Plugin saved = pluginService.create(plugin);
+
+    assertThat(PluginService.isPythonPluginUrl(url)).isTrue();
+    assertThat(saved.getName()).isEqualTo("Demo");
+    assertThat(saved.getContent()).isEqualTo(content);
+}
+
+@Test
+void refreshShouldReplaceRawPythonContent() {
+    Plugin plugin = new Plugin();
+    plugin.setId(21);
+    plugin.setName("Demo");
+    plugin.setSourceName("Demo");
+    plugin.setUrl("https://example.com/plugins/demo.py");
+    plugin.setContent("old");
+
+    when(pluginRepository.findById(21)).thenReturn(Optional.of(plugin));
+    when(restTemplate.getForObject(URI.create(plugin.getUrl()), String.class)).thenReturn("new");
+    when(pluginRepository.save(any(Plugin.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    Plugin refreshed = pluginService.refresh(21);
+
+    assertThat(PluginService.isPythonPluginUrl(plugin.getUrl())).isTrue();
+    assertThat(refreshed.getContent()).isEqualTo("new");
+}
+
+@Test
+void pythonPluginClassifierShouldRejectTxtAndInvalidUrls() {
+    assertThat(PluginService.isPythonPluginUrl("https://example.com/demo.txt")).isFalse();
+    assertThat(PluginService.isPythonPluginUrl("not a url")).isFalse();
+    assertThat(PluginService.isPythonPluginUrl(null)).isFalse();
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+mvn -q -Dtest=PluginServiceTest test
+```
+
+Expected: compilation fails because `PluginService.isPythonPluginUrl` does not exist.
+
+- [ ] **Step 3: Implement URI-path classification**
+
+Add this package-visible helper near the other URL helpers in `PluginService`:
+
+```java
+static boolean isPythonPluginUrl(String url) {
+    try {
+        String path = URI.create(StringUtils.trimToEmpty(url)).getPath();
+        return StringUtils.endsWithIgnoreCase(path, ".py");
+    } catch (Exception e) {
+        return false;
+    }
+}
+```
+
+This intentionally inspects only the parsed path, so `.PY?raw=1` is Python while `.txt?file=demo.py` is not.
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```bash
+mvn -q -Dtest=PluginServiceTest test
+```
+
+Expected: all `PluginServiceTest` tests pass.
+
+- [ ] **Step 5: Commit classifier and lifecycle coverage**
+
+```bash
+git add src/main/java/cn/har01d/alist_tvbox/service/PluginService.java src/test/java/cn/har01d/alist_tvbox/service/PluginServiceTest.java
+git commit -m "feat: classify raw Python plugins"
+```
+
+### Task 2: Serve cached Python content with Token authentication
+
+**Files:**
+- Create: `src/test/java/cn/har01d/alist_tvbox/web/PluginContentControllerTest.java`
+- Modify: `src/main/java/cn/har01d/alist_tvbox/web/PluginContentController.java`
+
+- [ ] **Step 1: Write the failing controller tests**
+
+Create the test with the same standalone MockMvc pattern used by other controllers:
+
+```java
+package cn.har01d.alist_tvbox.web;
+
+import cn.har01d.alist_tvbox.config.RestErrorHandler;
+import cn.har01d.alist_tvbox.exception.BadRequestException;
+import cn.har01d.alist_tvbox.service.PluginService;
+import cn.har01d.alist_tvbox.service.SubscriptionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class PluginContentControllerTest {
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private PluginService pluginService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        PluginContentController controller = new PluginContentController(subscriptionService, pluginService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new RestErrorHandler())
+                .build();
+    }
+
+    @Test
+    void pythonContentShouldAuthenticateAndReturnCachedSource() throws Exception {
+        when(pluginService.readContent(7)).thenReturn("class Spider:\n    pass\n");
+
+        mockMvc.perform(get("/plugins/test-token/7.py"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/x-python;charset=UTF-8"))
+                .andExpect(content().string("class Spider:\n    pass\n"));
+
+        verify(subscriptionService).checkToken("test-token");
+        verify(pluginService).readContent(7);
+    }
+
+    @Test
+    void pythonContentShouldNotReadPluginWhenTokenIsRejected() throws Exception {
+        doThrow(new BadRequestException("Token不正确"))
+                .when(subscriptionService).checkToken("bad-token");
+
+        mockMvc.perform(get("/plugins/bad-token/7.py"))
+                .andExpect(status().isBadRequest());
+
+        verify(pluginService, never()).readContent(7);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+mvn -q -Dtest=PluginContentControllerTest test
+```
+
+Expected: the success test receives `404` because no `.py` mapping exists.
+
+- [ ] **Step 3: Add the Python content route**
+
+Keep the `.txt` method unchanged and add:
+
+```java
+@GetMapping(value = "/plugins/{token}/{id}.py", produces = "text/x-python;charset=UTF-8")
+public String pythonContent(@PathVariable String token, @PathVariable Integer id) {
+    subscriptionService.checkToken(token);
+    return pluginService.readContent(id);
+}
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run:
+
+```bash
+mvn -q -Dtest=PluginContentControllerTest test
+```
+
+Expected: both controller tests pass.
+
+- [ ] **Step 5: Commit the authenticated content endpoint**
+
+```bash
+git add src/main/java/cn/har01d/alist_tvbox/web/PluginContentController.java src/test/java/cn/har01d/alist_tvbox/web/PluginContentControllerTest.java
+git commit -m "feat: serve cached Python plugin content"
+```
+
+### Task 3: Generate PyProxy loader payloads for raw Python
+
+**Files:**
+- Modify: `src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java`
+- Modify: `src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java`
+
+- [ ] **Step 1: Write failing payload tests**
+
+Add focused tests for the package-visible pure helpers:
+
+```java
+@Test
+void rawPythonPluginShouldUsePyProxyLoaderAndLocalProxyInEveryRunMode() {
+    Plugin plugin = new Plugin();
+    plugin.setId(7);
+    plugin.setUrl("https://example.com/demo.py?raw=1");
+    plugin.setExtend("{\"site\":\"demo\"}");
+    Map<String, Object> localProxyConfig = new HashMap<>();
+    localProxyConfig.put("ALI", Map.of("enabled", true));
+
+    Map<String, Object> payload = SubscriptionService.buildPluginExtPayload(
+            plugin, "http://atv", "web", "vod-token", "secret", true, localProxyConfig);
+
+    assertThat(SubscriptionService.selectPluginApi(plugin, true, "http://atv"))
+            .isEqualTo("csp_PyProxy");
+    assertThat(payload)
+            .containsEntry("loader", "http://atv/plugins/web/7.py")
+            .containsEntry("api", "http://atv")
+            .containsEntry("token", "vod-token")
+            .containsEntry("secret", "secret")
+            .containsEntry("data", "{\"site\":\"demo\"}")
+            .containsEntry("local_proxy_config", localProxyConfig)
+            .doesNotContainKey("source");
+}
+
+@Test
+void encryptedTxtPluginShouldKeepSourceAndNativePythonModeBehavior() {
+    Plugin plugin = new Plugin();
+    plugin.setId(8);
+    plugin.setUrl("https://example.com/demo.txt");
+    Map<String, Object> localProxyConfig = new HashMap<>();
+    localProxyConfig.put("ALI", Map.of("enabled", true));
+
+    Map<String, Object> payload = SubscriptionService.buildPluginExtPayload(
+            plugin, "http://atv", "web", "", "secret", true, localProxyConfig);
+
+    assertThat(SubscriptionService.selectPluginApi(plugin, true, "http://atv"))
+            .isEqualTo("http://atv/Atvp.py");
+    assertThat(payload)
+            .containsEntry("source", "http://atv/plugins/web/8.txt")
+            .containsEntry("token", "-")
+            .doesNotContainKey("loader");
+    assertThat(payload.get("local_proxy_config"))
+            .isEqualTo(new HashMap<>());
+}
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+mvn -q -Dtest=SubscriptionServiceTest test
+```
+
+Expected: compilation fails because `buildPluginExtPayload` and `selectPluginApi` do not exist.
+
+- [ ] **Step 3: Add pure protocol helpers**
+
+Add these package-visible static helpers immediately before `buildPluginSite`:
+
+```java
+static String selectPluginApi(Plugin plugin, boolean nativePython, String baseUrl) {
+    if (PluginService.isPythonPluginUrl(plugin.getUrl())) {
+        return "csp_PyProxy";
+    }
+    return nativePython ? baseUrl + "/Atvp.py" : "csp_PyProxy";
+}
+
+static Map<String, Object> buildPluginExtPayload(Plugin plugin,
+                                                 String baseUrl,
+                                                 String contentToken,
+                                                 String token,
+                                                 String secret,
+                                                 boolean nativePython,
+                                                 Map<String, Object> localProxyConfig) {
+    boolean rawPython = PluginService.isPythonPluginUrl(plugin.getUrl());
+    Map<String, Object> map = new HashMap<>();
+    map.put("api", baseUrl);
+    String extension = rawPython ? ".py" : ".txt";
+    String contentUrl = baseUrl + "/plugins/" + contentToken + "/" + plugin.getId() + extension;
+    map.put(rawPython ? "loader" : "source", contentUrl);
+    map.put("token", token.isBlank() ? "-" : token);
+    map.put("secret", secret);
+    map.put("local_proxy_config", rawPython || !nativePython ? localProxyConfig : new HashMap<>());
+    if (StringUtils.isNotBlank(plugin.getExtend())) {
+        map.put("data", plugin.getExtend());
+    }
+    return map;
+}
+```
+
+- [ ] **Step 4: Wire helpers into `buildPluginSite`**
+
+Replace the current API choice and hand-built ext map with:
+
+```java
+String url = readHostAddress("");
+boolean nativePython = isNativePythonPluginRunMode();
+site.put("api", selectPluginApi(plugin, nativePython, url));
+```
+
+Then create the payload through the helper:
+
+```java
+Map<String, Object> map = buildPluginExtPayload(
+        plugin,
+        url,
+        getCurrentOrFirstToken(),
+        token,
+        secret,
+        nativePython,
+        readLocalProxyConfig()
+);
+```
+
+Leave special plugin flags, filter insertion, JSON serialization, Base64 encoding, jar, and site metadata unchanged.
+
+- [ ] **Step 5: Run service tests and verify GREEN**
+
+Run:
+
+```bash
+mvn -q -Dtest=SubscriptionServiceTest,PluginServiceTest test
+```
+
+Expected: both test classes pass, including the `.txt` regression.
+
+- [ ] **Step 6: Commit subscription generation**
+
+```bash
+git add src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java
+git commit -m "feat: load raw Python plugins through PyProxy"
+```
+
+### Task 4: Expose `.py` support in the subscription source form
+
+**Files:**
+- Modify: `web-ui/src/views/SubscriptionsView.test.mjs`
+- Modify: `web-ui/src/views/SubscriptionsView.vue`
+
+- [ ] **Step 1: Write the failing frontend test**
+
+Add:
+
+```javascript
+test('accepts encrypted txt and raw Python plugin addresses', () => {
+  assert.equal(viewSource.includes('placeholder="https://example.com/plugin.txt 或 plugin.py"'), true)
+})
+```
+
+- [ ] **Step 2: Run the frontend test and verify RED**
+
+Run:
+
+```bash
+npm test
+```
+
+from `web-ui/`.
+
+Expected: the new placeholder assertion fails because the view mentions only `plugin.txt`.
+
+- [ ] **Step 3: Update the input placeholder**
+
+Change the plugin URL input to:
+
+```vue
+<el-input v-model="pluginForm.url" style="width: 460px" placeholder="https://example.com/plugin.txt 或 plugin.py"/>
+```
+
+- [ ] **Step 4: Run the frontend tests and verify GREEN**
+
+Run:
+
+```bash
+npm test
+```
+
+from `web-ui/`.
+
+Expected: all Node tests pass.
+
+- [ ] **Step 5: Commit the UI contract**
+
+```bash
+git add web-ui/src/views/SubscriptionsView.vue web-ui/src/views/SubscriptionsView.test.mjs
+git commit -m "feat: show raw Python plugin support"
+```
+
+### Task 5: Verify the complete change
+
+**Files:**
+- Verify all files changed in Tasks 1-4.
+
+- [ ] **Step 1: Run focused backend coverage**
+
+```bash
+mvn -q -Dtest=PluginServiceTest,PluginContentControllerTest,SubscriptionServiceTest test
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run the complete backend suite**
+
+```bash
+mvn test -q
+```
+
+Expected: exit code `0` with no test failures.
+
+- [ ] **Step 3: Run frontend tests and production build**
+
+From `web-ui/`:
+
+```bash
+npm test
+npm run build
+```
+
+Expected: all tests pass and Vite completes the production build.
+
+- [ ] **Step 4: Check formatting and scope**
+
+```bash
+git diff --check master...HEAD
+git status --short
+git diff --stat master...HEAD
+```
+
+Expected: no whitespace errors, no untracked generated files, and only the planned backend, test, frontend, spec, and plan files are present.
+
+- [ ] **Step 5: Review generated protocol manually**
+
+Confirm from the passing assertions that:
+
+```text
+.py -> api=csp_PyProxy, ext.loader=/plugins/{token}/{id}.py
+.txt + java mode -> api=csp_PyProxy, ext.source=/plugins/{token}/{id}.txt
+.txt + python mode -> api={base}/Atvp.py, ext.source=/plugins/{token}/{id}.txt
+```
+
+No additional code commit is needed unless verification uncovers a defect; any fix must start with a failing regression test.
+

--- a/docs/superpowers/plans/2026-07-19-raw-python-plugin.md
+++ b/docs/superpowers/plans/2026-07-19-raw-python-plugin.md
@@ -489,4 +489,3 @@ Confirm from the passing assertions that:
 ```
 
 No additional code commit is needed unless verification uncovers a defect; any fix must start with a failing regression test.
-

--- a/docs/superpowers/specs/2026-07-19-raw-python-backend-parse-design.md
+++ b/docs/superpowers/specs/2026-07-19-raw-python-backend-parse-design.md
@@ -98,4 +98,3 @@ Plugin.content (.py)
 2. 新增 Python Atvp 单元测试，构造 raw ext 和最小内层 Spider；让 `_decrypt_secspider_source` 在被调用时抛错，证明 raw 分支必须跳过它。
 3. 在同一 Python 测试中让内层 Spider 设置 `backend_parse=True`，验证分类结果被改写为 `Atvp.DETAIL_PREFIX`，并模拟 `/parse`/`/play` 响应验证后端端点调用。
 4. 实现最小修改后运行 Java 聚焦测试、Python 单元测试、完整 `mvn test`、前端测试和构建。
-

--- a/docs/superpowers/specs/2026-07-19-raw-python-backend-parse-design.md
+++ b/docs/superpowers/specs/2026-07-19-raw-python-backend-parse-design.md
@@ -1,0 +1,101 @@
+# 原始 Python 爬虫 backend_parse 兼容设计
+
+## 背景与根因
+
+原始 Python 插件目前通过 `csp_PyProxy` 将 `loader` 指向插件自己的 `.py` 文件。这样 `PyProxy` 会直接实例化原始 Spider，绕过 `src/main/resources/static/Atvp.py`。
+
+`Atvp.py` 并不是单纯的加密文件加载器，它还实现了 `backend_parse=True` 的运行时协议：
+
+- 首页、首页视频、分类和搜索结果改写为可展开的目录项；
+- 详情结果缓存网盘信息和播放上下文；
+- 对原始网盘链接调用后端 `/parse/{token}`；
+- 对 `1@...` 播放标识调用后端 `/play/{token}`；
+- 将目录项、详情和播放上下文传给过滤器。
+
+因此，原始 Python 插件即使设置 `self.backend_parse = True`，当前也不会得到这些行为。
+
+## 目标
+
+- 原始 `.py` 插件也通过 `Atvp.py` 运行时包装。
+- `backend_parse=True` 的原始 Python 爬虫复用现有目录、详情、解析和播放逻辑。
+- `.txt` 加密插件的协议和行为完全不变。
+- 不修改外部 CatVod 工程、`PyProxy.java` 或重新构建 `spring.jar`。
+- 原始 Python 插件的 `data`、Token 和本地代理配置按 Atvp 既有规则传给内层 Spider。
+
+## 非目标
+
+- 不在 Java `PyProxy` 中复制 Python 运行时逻辑。
+- 不改变后端 `/parse/{token}` 和 `/play/{token}` 的 API 结构。
+- 不改变插件 URL 类型识别、缓存、刷新和鉴权规则。
+
+## 设计
+
+### 订阅 ext 协议
+
+原始 `.py` 站点仍使用 `api: "csp_PyProxy"`，但 ext 改为：
+
+```json
+{
+  "loader": "ATV_ADDRESS/Atvp.py",
+  "api": "ATV_ADDRESS",
+  "source": "ATV_ADDRESS/plugins/TOKEN/ID.py",
+  "raw": true,
+  "token": "TOKEN",
+  "secret": "SECRET",
+  "data": "PLUGIN_EXTEND",
+  "local_proxy_config": {}
+}
+```
+
+`loader` 选择 Atvp 包装器，`source` 保持原始 Python 内容接口。`raw: true` 是显式协议标志，只对原始 Python 生效；它避免通过文件后缀猜测是否跳过解密。
+
+加密 `.txt` 继续使用当前 `loader`/`source` 组合和 Atvp 加密解包路径，不增加 `raw` 字段。
+
+### Atvp.py 原始源分支
+
+`Spider.init` 读取 ext 后，仍通过 `_load_source(source)` 获取文本。随后按 payload 的 `raw` 布尔值选择：
+
+```python
+package_text = self._load_source(source)
+source_text = package_text if self._is_raw_source(payload) else self._decrypt_secspider_source(package_text)
+```
+
+新增 `_is_raw_source(payload)` 只接受字典中的真值 `raw`，非字典或缺失字段均返回 `False`。除源文本取得方式外，内层 Spider 的加载、`_compose_inner_extend`、backend API、Token、过滤器和所有 `backend_parse` 分支不变。
+
+### 数据流
+
+```text
+Plugin.content (.py)
+    -> GET /plugins/{token}/{id}.py
+    -> PyProxy(loader=Atvp.py)
+    -> Atvp._load_source(source)
+    -> raw=true: 跳过 secspider 解密
+    -> inner Spider.init(data + token + proxy)
+    -> backend_parse=True 的 Atvp 目录/详情/parse/play 协议
+```
+
+### 错误处理与兼容性
+
+- `raw` 缺失或为假时仍严格执行现有 secspider 解密，防止误把加密文本当作 Python 执行。
+- 原始源下载失败、内容为空、Token 错误继续使用现有后端错误处理。
+- Atvp 原始源执行失败时沿用 PyProxy 的初始化错误行为，不向后端引入新的错误格式。
+- 现有 `.txt` ext 快照和 Java 代理/原生 Python 运行模式测试必须继续通过。
+
+## 代码边界
+
+- `src/main/resources/static/Atvp.py`
+  - 增加 raw payload 判断和跳过解密分支。
+- `src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java`
+  - 原始 Python ext 将 `loader` 改为 `/Atvp.py`，增加 `source` 和 `raw: true`。
+- `src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java`
+  - 验证原始 Python 的 loader/source/raw 字段和 `.txt` 回归。
+- `src/test/python/test_Atvp_raw_backend_parse.py`
+  - 验证 raw 源跳过解密，并验证 `backend_parse=True` 的 Atvp 分类/解析播放路径仍可执行。
+
+## 测试策略
+
+1. 先新增 Java ext 测试，确认原始 Python 输出 `loader=/Atvp.py`、`source=.py`、`raw=true`，当前实现应失败。
+2. 新增 Python Atvp 单元测试，构造 raw ext 和最小内层 Spider；让 `_decrypt_secspider_source` 在被调用时抛错，证明 raw 分支必须跳过它。
+3. 在同一 Python 测试中让内层 Spider 设置 `backend_parse=True`，验证分类结果被改写为 `Atvp.DETAIL_PREFIX`，并模拟 `/parse`/`/play` 响应验证后端端点调用。
+4. 实现最小修改后运行 Java 聚焦测试、Python 单元测试、完整 `mvn test`、前端测试和构建。
+

--- a/docs/superpowers/specs/2026-07-19-raw-python-plugin-design.md
+++ b/docs/superpowers/specs/2026-07-19-raw-python-plugin-design.md
@@ -1,0 +1,105 @@
+# 原始 Python 订阅源插件设计
+
+## 背景
+
+当前订阅源插件将远程 `.txt` 内容保存到 `Plugin.content`，客户端通过 `Atvp.py` 解密并加载。订阅配置通常使用 `csp_PyProxy`，由 `PyProxy.java` 转发到 `Atvp.py`。
+
+需要在不破坏现有加密 `.txt` 插件的前提下，支持原始 `.py` 爬虫入口，并继续使用 `PyProxy.java` 转发。
+
+## 目标与非目标
+
+目标：
+
+- 手工添加和 `spiders_v2.json` 导入均支持 `.py` URL。
+- `.py` 内容由后端下载、缓存、刷新，并通过现有 Token 鉴权接口提供给客户端。
+- 客户端订阅配置对 `.py` 使用 `csp_PyProxy` 的 `loader` 字段直接加载本地 Python 内容。
+- `.txt` 的识别、下载、加密解析、订阅输出和运行模式保持兼容。
+- 覆盖后端服务、内容接口和订阅配置生成的自动化测试。
+
+非目标：
+
+- 不新增数据库 `type` 字段或 Flyway 迁移。
+- 不修改外部 CatVod 工程或重新构建 `spring.jar`；本变更只使用现有 `PyProxy.java` 已支持的 `loader` 协议。
+- 不改变 Python 爬虫自身的运行时 API，也不把 Python 代码在后端执行。
+
+## 方案
+
+### 类型识别
+
+插件类型由 `Plugin.url` 的 URI path 后缀决定：忽略大小写，path 以 `.py` 结尾时视为原始 Python，其他 URL（包括现有 `.txt` 和无扩展名地址）继续按加密文本处理。查询参数和片段不影响判断。该判断集中在 `PluginService` 或共享的包级辅助方法中，避免控制器和订阅服务各自解析。
+
+元数据解析仍从下载内容中读取 `//@id`、`//@version`、`//@name`。没有这些头部时继续使用 URL 文件名作为默认名称；因此普通 Python 源也可以没有 CatVod 元数据头。
+
+### 内容转发
+
+保留现有 `GET /plugins/{token}/{id}.txt`，新增 `GET /plugins/{token}/{id}.py`。两个端点都先调用 `SubscriptionService.checkToken(token)`，再调用 `PluginService.readContent(id)`，避免重复读取逻辑。`.py` 端点使用 `text/x-python; charset=UTF-8`，`.txt` 的响应类型不变。内容为空或插件不存在时保持现有错误语义。
+
+### 订阅配置
+
+`SubscriptionService.buildPluginSite` 根据 URL 类型生成不同 ext：
+
+- 加密 `.txt`：保持现有 `api: "csp_PyProxy"`，ext 使用 `source: /plugins/{token}/{id}.txt`，并按现有设置写入 `local_proxy_config`。
+- 原始 `.py`：始终使用 `api: "csp_PyProxy"`，ext 使用 `loader: /plugins/{token}/{id}.py`，同时保留后端 `api`、`token`、`secret` 和可选 `data`（插件扩展配置）。原始 Python 不经过 `Atvp.py` 解密；`PyProxy` 根据 `loader` 直接创建 Python Spider，并把原始 ext 传给它。
+
+原生 Python 运行模式开关只继续影响现有加密 `.txt` 插件的 `Atvp.py` 路径。`.py` 插件按需求固定走 `PyProxy`，这样无论全局模式如何设置，都能使用统一的本地内容转发和播放代理行为。
+
+URL 构造复用当前主机地址、Token 和插件 ID 规则；插件地址本身不下发给客户端，客户端只访问后端缓存接口。
+
+### 生命周期与错误处理
+
+创建、刷新、仓库导入沿用 `PluginService` 的下载和元数据流程。刷新失败时保留之前的 `content`，更新 `lastError` 和 `lastCheckedAt`，与 `.txt` 保持一致。URL 后缀变化时，下一次订阅生成按新类型输出，不需要迁移已有数据。
+
+继续使用现有外部 URL 安全校验和 GitHub 代理 fallback；新增 `.py` 端点不接受路径文件名作为本地路径，只按数据库 ID 查询，避免路径穿越。
+
+## 代码边界
+
+- `src/main/java/cn/har01d/alist_tvbox/service/PluginService.java`
+  - 增加可复用的 Python URL 判断。
+  - 保持下载、刷新、元数据和内容读取职责不变。
+- `src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java`
+  - 在 `buildPluginSite` 中按插件类型生成 `.txt` 或 `.py` ext。
+- `src/main/java/cn/har01d/alist_tvbox/web/PluginContentController.java`
+  - 增加鉴权的 `.py` 内容映射，复用 `readContent`。
+- `web-ui/src/views/SubscriptionsView.vue`
+  - 将插件地址提示改为同时说明 `.txt/.py`，不新增类型表单或状态字段。
+- `src/test/java/cn/har01d/alist_tvbox/service/PluginServiceTest.java`
+  - 增加 `.py` 创建、刷新和 URL 类型判断测试。
+- `src/test/java/cn/har01d/alist_tvbox/web/PluginContentControllerTest.java`（新建）
+  - 覆盖 `.py` 端点 Token 校验、响应媒体类型和内容复用。
+- `src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java`
+  - 覆盖 `.py` 站点的 `csp_PyProxy`、`loader`、本地 `.py` 地址和 ext 字段，并验证 `.txt` 输出未改变。
+- `web-ui/src/views/SubscriptionsView.test.mjs`
+  - 覆盖地址提示包含 `.txt` 和 `.py`。
+
+## 数据流
+
+```text
+远程 .py URL
+    │ PluginService.create/refresh/download
+    ▼
+Plugin.content（原始 Python 文本）
+    │ SubscriptionService.buildPluginSite
+    ▼
+ext = base64({loader: /plugins/{token}/{id}.py, api, token, secret, data})
+    │ 客户端加载 csp_PyProxy
+    ▼
+PyProxy.java -> GET /plugins/{token}/{id}.py -> 原始 Python Spider
+```
+
+`.txt` 仍沿用 `source` 加载和 `Atvp.py` 解密分支。
+
+## 测试策略
+
+先为每个新行为添加失败测试，再实现最小改动：
+
+1. `PluginServiceTest` 验证 `.py` 内容按原文保存、刷新覆盖、没有 Python 头部时按文件名命名，以及带查询参数的 `.py` URL 仍被识别。
+2. 内容控制器测试验证合法 Token 返回 Python 文本和正确 Content-Type，非法 Token 不读取插件内容。
+3. 订阅服务测试解码 ext，验证 `.py` 使用 `loader` 而不是 `source`，同时验证 `.txt` 仍使用 `source`。
+4. 前端静态测试验证输入提示和现有插件添加流程没有破坏。
+5. 完成后运行对应 Maven 测试、前端测试和完整 `mvn test`。
+
+## 风险与兼容性
+
+- 依赖 URL 后缀；没有 `.py` 后缀的原始 Python 地址仍会按 `.txt` 处理，这是为保持旧数据兼容而作的明确约束。
+- 客户端必须包含支持 `PyProxy.loader` 的 `spring.jar`；当前引用的 `PyProxy.java` 已实现该协议，服务器端不修改 jar。
+- Python 爬虫收到的是 PyProxy 的完整 ext 字符串；`data` 继续作为插件自定义配置入口。现有 `.txt` 的 Atvp 解密配置不受影响。

--- a/src/main/java/cn/har01d/alist_tvbox/service/PluginService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/PluginService.java
@@ -153,7 +153,10 @@ public class PluginService {
 
             try {
                 Plugin existing = findExistingPlugin(normalizedPluginUrl, entry.externalId());
-                if (existing != null && entry.version() != null && entry.version().equals(existing.getVersion())) {
+                boolean samePluginType = existing != null
+                        && isPythonPluginUrl(existing.getUrl()) == isPythonPluginUrl(normalizedPluginUrl);
+                if (existing != null && samePluginType
+                        && entry.version() != null && entry.version().equals(existing.getVersion())) {
                     backfillImportMetadata(existing, normalizedPluginUrl, entry.externalId());
                     skipped.add(normalizedPluginUrl);
                     continue;
@@ -481,7 +484,15 @@ public class PluginService {
     }
 
     String deriveSourceName(String url) {
-        String raw = url.substring(url.lastIndexOf('/') + 1);
+        String source = url;
+        try {
+            String path = URI.create(url).getRawPath();
+            if (StringUtils.isNotBlank(path)) {
+                source = path;
+            }
+        } catch (Exception ignored) {
+        }
+        String raw = source.substring(source.lastIndexOf('/') + 1);
         String decoded = URLDecoder.decode(raw, StandardCharsets.UTF_8);
         int dot = decoded.lastIndexOf('.');
         return dot > 0 ? decoded.substring(0, dot) : decoded;

--- a/src/main/java/cn/har01d/alist_tvbox/service/PluginService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/PluginService.java
@@ -575,6 +575,15 @@ public class PluginService {
         return StringUtils.appendIfMissing(proxy, "/") + url;
     }
 
+    static boolean isPythonPluginUrl(String url) {
+        try {
+            String path = URI.create(StringUtils.trimToEmpty(url)).getPath();
+            return StringUtils.endsWithIgnoreCase(path, ".py");
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     private void applyDownloadedPlugin(Plugin plugin, DownloadedPlugin downloadedPlugin, String entryExternalId, boolean updateName) {
         plugin.setSourceName(downloadedPlugin.sourceName());
         if (updateName) {

--- a/src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java
@@ -1424,6 +1424,35 @@ public class SubscriptionService {
         return site;
     }
 
+    static String selectPluginApi(Plugin plugin, boolean nativePython, String baseUrl) {
+        if (PluginService.isPythonPluginUrl(plugin.getUrl())) {
+            return "csp_PyProxy";
+        }
+        return nativePython ? baseUrl + "/Atvp.py" : "csp_PyProxy";
+    }
+
+    static Map<String, Object> buildPluginExtPayload(Plugin plugin,
+                                                     String baseUrl,
+                                                     String contentToken,
+                                                     String token,
+                                                     String secret,
+                                                     boolean nativePython,
+                                                     Map<String, Object> localProxyConfig) {
+        boolean rawPython = PluginService.isPythonPluginUrl(plugin.getUrl());
+        Map<String, Object> map = new HashMap<>();
+        map.put("api", baseUrl);
+        String extension = rawPython ? ".py" : ".txt";
+        String contentUrl = baseUrl + "/plugins/" + contentToken + "/" + plugin.getId() + extension;
+        map.put(rawPython ? "loader" : "source", contentUrl);
+        map.put("token", token.isBlank() ? "-" : token);
+        map.put("secret", secret);
+        map.put("local_proxy_config", rawPython || !nativePython ? localProxyConfig : new HashMap<>());
+        if (StringUtils.isNotBlank(plugin.getExtend())) {
+            map.put("data", plugin.getExtend());
+        }
+        return map;
+    }
+
     private Map<String, Object> buildPluginSite(Plugin plugin, String token, String secret) throws JsonProcessingException {
         Map<String, Object> site = new HashMap<>();
         site.put("filterable", 1);
@@ -1432,7 +1461,7 @@ public class SubscriptionService {
         site.put("changeable", 0);
         String url = readHostAddress("");
         boolean nativePython = isNativePythonPluginRunMode();
-        site.put("api", nativePython ? url + "/Atvp.py" : "csp_PyProxy");
+        site.put("api", selectPluginApi(plugin, nativePython, url));
         site.put("type", 3);
         site.put("key", plugin.getName());
         site.put("searchable", 1);
@@ -1443,17 +1472,15 @@ public class SubscriptionService {
             site.put("indexs", 1);
         }
 
-        Map<String, Object> map = new HashMap<>();
-        map.put("api", url);
-        //map.put("loader", url + "/Atvp.py");
-        String source = readHostAddress("") + "/plugins/" + getCurrentOrFirstToken() + "/" + plugin.getId() + ".txt";
-        map.put("source", source);
-        map.put("token", token.isBlank() ? "-" : token);
-        map.put("secret", secret);
-        map.put("local_proxy_config", nativePython ? new HashMap<>() : readLocalProxyConfig());
-        if (StringUtils.isNotBlank(plugin.getExtend())) {
-            map.put("data", plugin.getExtend());
-        }
+        Map<String, Object> map = buildPluginExtPayload(
+                plugin,
+                url,
+                getCurrentOrFirstToken(),
+                token,
+                secret,
+                nativePython,
+                readLocalProxyConfig()
+        );
         // 每个插件站点只下发与自己作用域匹配的过滤器
         List<Map<String, Object>> filters = buildPluginFilters(plugin);
         if (!filters.isEmpty()) {

--- a/src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java
@@ -1443,7 +1443,13 @@ public class SubscriptionService {
         map.put("api", baseUrl);
         String extension = rawPython ? ".py" : ".txt";
         String contentUrl = baseUrl + "/plugins/" + contentToken + "/" + plugin.getId() + extension;
-        map.put(rawPython ? "loader" : "source", contentUrl);
+        if (rawPython) {
+            map.put("loader", baseUrl + "/Atvp.py");
+            map.put("source", contentUrl);
+            map.put("raw", true);
+        } else {
+            map.put("source", contentUrl);
+        }
         map.put("token", token.isBlank() ? "-" : token);
         map.put("secret", secret);
         map.put("local_proxy_config", rawPython || !nativePython ? localProxyConfig : new HashMap<>());

--- a/src/main/java/cn/har01d/alist_tvbox/web/PluginContentController.java
+++ b/src/main/java/cn/har01d/alist_tvbox/web/PluginContentController.java
@@ -22,4 +22,10 @@ public class PluginContentController {
         subscriptionService.checkToken(token);
         return pluginService.readContent(id);
     }
+
+    @GetMapping(value = "/plugins/{token}/{id}.py", produces = "text/x-python;charset=UTF-8")
+    public String pythonContent(@PathVariable String token, @PathVariable Integer id) {
+        subscriptionService.checkToken(token);
+        return pluginService.readContent(id);
+    }
 }

--- a/src/main/resources/static/Atvp.py
+++ b/src/main/resources/static/Atvp.py
@@ -200,7 +200,7 @@ class Spider(HostSpider):
         self._vod_token = self._resolve_vod_token(payload)
         self._localProxyConfig = payload.get("local_proxy_config") if isinstance(payload, dict) else {}
         package_text = self._load_source(source)
-        source_text = self._decrypt_secspider_source(package_text)
+        source_text = package_text if self._is_raw_source(payload) else self._decrypt_secspider_source(package_text)
         spider_cls = self._load_inner_spider_class(source_text)
         self._inner = spider_cls()
         result = self._inner.init(inner_extend)
@@ -240,6 +240,9 @@ class Spider(HostSpider):
         if not isinstance(payload, dict):
             return None
         return payload if payload.get("source") or payload.get("api") else None
+
+    def _is_raw_source(self, payload):
+        return isinstance(payload, dict) and payload.get("raw") is True
 
     def _compose_inner_extend(self, payload):
         data_value = payload.get("data")

--- a/src/test/java/cn/har01d/alist_tvbox/service/PluginServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/PluginServiceTest.java
@@ -187,6 +187,13 @@ class PluginServiceTest {
     }
 
     @Test
+    void deriveSourceNameShouldIgnoreQueryDots() {
+        assertThat(pluginService.deriveSourceName(
+                "https://example.com/plugins/demo.py?download=release.v1#source"))
+                .isEqualTo("demo");
+    }
+
+    @Test
     void pythonPluginClassifierShouldRejectTxtAndInvalidUrls() {
         assertThat(PluginService.isPythonPluginUrl("https://example.com/demo.txt")).isFalse();
         assertThat(PluginService.isPythonPluginUrl("not a url")).isFalse();
@@ -575,6 +582,35 @@ class PluginServiceTest {
         assertThat(result.failedCount()).isEqualTo(0);
         assertThat(existing.getContent()).isEqualTo("stable");
         verify(restTemplate, never()).getForObject(URI.create(pluginUrl), String.class);
+    }
+
+    @Test
+    void importShouldRefreshWhenSameVersionChangesBetweenTxtAndPython() {
+        String sourceUrl = "https://github.com/har01d5/tvbox/raw/refs/heads/master/spiders_v2.json";
+        String oldPluginUrl = "https://github.com/har01d5/tvbox/raw/refs/heads/master/py/demo.txt";
+        String newPluginUrl = "https://github.com/har01d5/tvbox/raw/refs/heads/master/py/demo.py";
+        String externalId = "demo-id";
+        String payload = "[{\"id\":\"" + externalId + "\",\"version\":1,\"file\":\"py/demo.py\"}]";
+        Plugin existing = new Plugin();
+        existing.setId(12);
+        existing.setName("demo");
+        existing.setSourceName("demo");
+        existing.setExternalId(externalId);
+        existing.setUrl(oldPluginUrl);
+        existing.setVersion(1);
+        existing.setContent("encrypted-text");
+
+        when(restTemplate.getForObject(URI.create(sourceUrl), String.class)).thenReturn(payload);
+        when(pluginRepository.findByExternalId(externalId)).thenReturn(Optional.of(existing));
+        when(restTemplate.getForObject(URI.create(newPluginUrl), String.class)).thenReturn("class Spider: pass");
+        when(pluginRepository.findById(12)).thenReturn(Optional.of(existing));
+        when(pluginRepository.save(any(Plugin.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PluginService.ImportResult result = pluginService.importFromSource(sourceUrl);
+
+        assertThat(result.refreshed()).containsExactly("demo");
+        assertThat(existing.getUrl()).isEqualTo(newPluginUrl);
+        assertThat(existing.getContent()).isEqualTo("class Spider: pass");
     }
 
     @Test

--- a/src/test/java/cn/har01d/alist_tvbox/service/PluginServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/PluginServiceTest.java
@@ -94,6 +94,24 @@ class PluginServiceTest {
     }
 
     @Test
+    void createShouldStoreRawPythonContentAndClassifyUrlPathWithQuery() {
+        String url = "https://example.com/plugins/Demo.PY?raw=1";
+        String content = "class Spider:\n    pass\n";
+        Plugin plugin = new Plugin();
+        plugin.setUrl(url);
+
+        when(pluginRepository.findByUrl(url)).thenReturn(Optional.empty());
+        when(restTemplate.getForObject(URI.create(url), String.class)).thenReturn(content);
+        when(pluginRepository.save(any(Plugin.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Plugin saved = pluginService.create(plugin);
+
+        assertThat(PluginService.isPythonPluginUrl(url)).isTrue();
+        assertThat(saved.getName()).isEqualTo("Demo");
+        assertThat(saved.getContent()).isEqualTo(content);
+    }
+
+    @Test
     void createShouldRejectUnreachableUrl() {
         Plugin plugin = new Plugin();
         plugin.setUrl("https://example.com/missing.txt");
@@ -147,6 +165,32 @@ class PluginServiceTest {
 
         assertThat(refreshed.getContent()).isEqualTo("stable-body");
         assertThat(refreshed.getLastError()).contains("插件地址不可访问");
+    }
+
+    @Test
+    void refreshShouldReplaceRawPythonContent() {
+        Plugin plugin = new Plugin();
+        plugin.setId(21);
+        plugin.setName("Demo");
+        plugin.setSourceName("Demo");
+        plugin.setUrl("https://example.com/plugins/demo.py");
+        plugin.setContent("old");
+
+        when(pluginRepository.findById(21)).thenReturn(Optional.of(plugin));
+        when(restTemplate.getForObject(URI.create(plugin.getUrl()), String.class)).thenReturn("new");
+        when(pluginRepository.save(any(Plugin.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Plugin refreshed = pluginService.refresh(21);
+
+        assertThat(PluginService.isPythonPluginUrl(plugin.getUrl())).isTrue();
+        assertThat(refreshed.getContent()).isEqualTo("new");
+    }
+
+    @Test
+    void pythonPluginClassifierShouldRejectTxtAndInvalidUrls() {
+        assertThat(PluginService.isPythonPluginUrl("https://example.com/demo.txt")).isFalse();
+        assertThat(PluginService.isPythonPluginUrl("not a url")).isFalse();
+        assertThat(PluginService.isPythonPluginUrl(null)).isFalse();
     }
 
     @Test

--- a/src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java
@@ -165,4 +165,49 @@ class SubscriptionServiceTest {
         List<Map<String, Object>> parses = (List<Map<String, Object>>) catalog.get("parses");
         assertThat(parses).extracting(p -> p.get("name")).containsExactly("虾米");
     }
+
+    @Test
+    void rawPythonPluginShouldUsePyProxyLoaderAndLocalProxyInEveryRunMode() {
+        Plugin plugin = new Plugin();
+        plugin.setId(7);
+        plugin.setUrl("https://example.com/demo.py?raw=1");
+        plugin.setExtend("{\"site\":\"demo\"}");
+        Map<String, Object> localProxyConfig = new HashMap<>();
+        localProxyConfig.put("ALI", Map.of("enabled", true));
+
+        Map<String, Object> payload = SubscriptionService.buildPluginExtPayload(
+                plugin, "http://atv", "web", "vod-token", "secret", true, localProxyConfig);
+
+        assertThat(SubscriptionService.selectPluginApi(plugin, true, "http://atv"))
+                .isEqualTo("csp_PyProxy");
+        assertThat(payload)
+                .containsEntry("loader", "http://atv/plugins/web/7.py")
+                .containsEntry("api", "http://atv")
+                .containsEntry("token", "vod-token")
+                .containsEntry("secret", "secret")
+                .containsEntry("data", "{\"site\":\"demo\"}")
+                .containsEntry("local_proxy_config", localProxyConfig)
+                .doesNotContainKey("source");
+    }
+
+    @Test
+    void encryptedTxtPluginShouldKeepSourceAndNativePythonModeBehavior() {
+        Plugin plugin = new Plugin();
+        plugin.setId(8);
+        plugin.setUrl("https://example.com/demo.txt");
+        Map<String, Object> localProxyConfig = new HashMap<>();
+        localProxyConfig.put("ALI", Map.of("enabled", true));
+
+        Map<String, Object> payload = SubscriptionService.buildPluginExtPayload(
+                plugin, "http://atv", "web", "", "secret", true, localProxyConfig);
+
+        assertThat(SubscriptionService.selectPluginApi(plugin, true, "http://atv"))
+                .isEqualTo("http://atv/Atvp.py");
+        assertThat(payload)
+                .containsEntry("source", "http://atv/plugins/web/8.txt")
+                .containsEntry("token", "-")
+                .doesNotContainKey("loader");
+        assertThat(payload.get("local_proxy_config"))
+                .isEqualTo(new HashMap<>());
+    }
 }

--- a/src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java
@@ -180,6 +180,8 @@ class SubscriptionServiceTest {
 
         assertThat(SubscriptionService.selectPluginApi(plugin, true, "http://atv"))
                 .isEqualTo("csp_PyProxy");
+        assertThat(SubscriptionService.selectPluginApi(plugin, false, "http://atv"))
+                .isEqualTo("csp_PyProxy");
         assertThat(payload)
                 .containsEntry("loader", "http://atv/plugins/web/7.py")
                 .containsEntry("api", "http://atv")
@@ -203,11 +205,17 @@ class SubscriptionServiceTest {
 
         assertThat(SubscriptionService.selectPluginApi(plugin, true, "http://atv"))
                 .isEqualTo("http://atv/Atvp.py");
+        assertThat(SubscriptionService.selectPluginApi(plugin, false, "http://atv"))
+                .isEqualTo("csp_PyProxy");
         assertThat(payload)
                 .containsEntry("source", "http://atv/plugins/web/8.txt")
                 .containsEntry("token", "-")
                 .doesNotContainKey("loader");
         assertThat(payload.get("local_proxy_config"))
                 .isEqualTo(new HashMap<>());
+
+        Map<String, Object> javaPayload = SubscriptionService.buildPluginExtPayload(
+                plugin, "http://atv", "web", "", "secret", false, localProxyConfig);
+        assertThat(javaPayload.get("local_proxy_config")).isEqualTo(localProxyConfig);
     }
 }

--- a/src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/SubscriptionServiceTest.java
@@ -183,13 +183,15 @@ class SubscriptionServiceTest {
         assertThat(SubscriptionService.selectPluginApi(plugin, false, "http://atv"))
                 .isEqualTo("csp_PyProxy");
         assertThat(payload)
-                .containsEntry("loader", "http://atv/plugins/web/7.py")
+                .containsEntry("loader", "http://atv/Atvp.py")
+                .containsEntry("source", "http://atv/plugins/web/7.py")
+                .containsEntry("raw", true)
                 .containsEntry("api", "http://atv")
                 .containsEntry("token", "vod-token")
                 .containsEntry("secret", "secret")
                 .containsEntry("data", "{\"site\":\"demo\"}")
-                .containsEntry("local_proxy_config", localProxyConfig)
-                .doesNotContainKey("source");
+                .containsEntry("local_proxy_config", localProxyConfig);
+        assertThat(payload.get("loader")).isNotEqualTo("http://atv/plugins/web/7.py");
     }
 
     @Test

--- a/src/test/java/cn/har01d/alist_tvbox/web/PluginContentControllerTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/web/PluginContentControllerTest.java
@@ -1,0 +1,63 @@
+package cn.har01d.alist_tvbox.web;
+
+import cn.har01d.alist_tvbox.config.RestErrorHandler;
+import cn.har01d.alist_tvbox.exception.BadRequestException;
+import cn.har01d.alist_tvbox.service.PluginService;
+import cn.har01d.alist_tvbox.service.SubscriptionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class PluginContentControllerTest {
+    @Mock
+    private SubscriptionService subscriptionService;
+    @Mock
+    private PluginService pluginService;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        PluginContentController controller = new PluginContentController(subscriptionService, pluginService);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new RestErrorHandler())
+                .build();
+    }
+
+    @Test
+    void pythonContentShouldAuthenticateAndReturnCachedSource() throws Exception {
+        when(pluginService.readContent(7)).thenReturn("class Spider:\n    pass\n");
+
+        mockMvc.perform(get("/plugins/test-token/7.py"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("text/x-python;charset=UTF-8"))
+                .andExpect(content().string("class Spider:\n    pass\n"));
+
+        verify(subscriptionService).checkToken("test-token");
+        verify(pluginService).readContent(7);
+    }
+
+    @Test
+    void pythonContentShouldNotReadPluginWhenTokenIsRejected() throws Exception {
+        doThrow(new BadRequestException("Token不正确"))
+                .when(subscriptionService).checkToken("bad-token");
+
+        mockMvc.perform(get("/plugins/bad-token/7.py"))
+                .andExpect(status().isBadRequest());
+
+        verify(pluginService, never()).readContent(7);
+    }
+}

--- a/src/test/python/test_Atvp_raw_backend_parse.py
+++ b/src/test/python/test_Atvp_raw_backend_parse.py
@@ -1,0 +1,96 @@
+import base64
+import json
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE = SourceFileLoader(
+    "atvp_raw_backend_parse",
+    str(ROOT / "src/main/resources/static/Atvp.py"),
+).load_module()
+Spider = MODULE.Spider
+
+
+class Response:
+    def __init__(self, status_code=200, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class TestAtvpRawBackendParse(unittest.TestCase):
+    def setUp(self):
+        Spider._instance = None
+        self.spider = Spider()
+
+    def build_ext(self):
+        payload = {
+            "loader": "https://atv.example/Atvp.py",
+            "api": "https://atv.example",
+            "source": "https://atv.example/plugins/demo/7.py",
+            "raw": True,
+            "token": "demo",
+            "local_proxy_config": {},
+        }
+        return base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+
+    def init_inner(self, source):
+        with (
+            patch.object(Spider, "_load_source", return_value=source),
+            patch.object(
+                Spider,
+                "_decrypt_secspider_source",
+                side_effect=AssertionError("raw source must not decrypt"),
+            ),
+        ):
+            self.spider.init(self.build_ext())
+
+    def test_raw_source_skips_secspider_decryption(self):
+        self.init_inner(
+            'class Spider:\n    def init(self, extend=""):\n        return None\n'
+        )
+
+        self.assertIsNotNone(self.spider._inner)
+
+    def test_backend_parse_rewrites_category_and_uses_backend_parse_and_play(self):
+        source = '''
+class Spider:
+    def init(self, extend=""):
+        self.backend_parse = True
+    def categoryContent(self, tid, pg, filter, extend):
+        return {"list": [{"vod_id": "movie-1", "vod_name": "Demo"}], "page": 1}
+    def detailContent(self, ids):
+        return {"list": [{"vod_id": ids[0], "vod_name": "Demo", "vod_play_from": "网盘", "vod_play_url": "网盘$1@share"}]}
+'''
+        self.init_inner(source)
+
+        home = self.spider.categoryContent("home", "1", False, {})
+        self.assertTrue(home["list"][0]["vod_id"].startswith(self.spider.DETAIL_PREFIX))
+        detail = self.spider.categoryContent(home["list"][0]["vod_id"], "1", False, {})
+        self.assertEqual(detail["list"][0]["vod_id"], "1@share")
+
+        self.spider.post = Mock(
+            return_value=Response(
+                text=json.dumps({"list": [{"vod_id": "share", "vod_name": "Parsed"}]})
+            )
+        )
+        parsed = self.spider.detailContent(["https://pan.example/share"])
+        self.assertEqual(parsed["list"][0]["vod_name"], "Parsed")
+
+        self.spider.fetch = Mock(
+            return_value=Response(
+                text=json.dumps(
+                    {"parse": 0, "url": "https://video.example/demo.m3u8"}
+                )
+            )
+        )
+        played = self.spider.playerContent("网盘", "1@share", [])
+        self.assertEqual(played["url"], "https://video.example/demo.m3u8")
+        self.spider.post.assert_called_once()
+        self.spider.fetch.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/test/python/test_Atvp_raw_backend_parse.py
+++ b/src/test/python/test_Atvp_raw_backend_parse.py
@@ -32,7 +32,8 @@ class TestAtvpRawBackendParse(unittest.TestCase):
             "source": "https://atv.example/plugins/demo/7.py",
             "raw": True,
             "token": "demo",
-            "local_proxy_config": {},
+            "data": {"site": "demo"},
+            "local_proxy_config": {"ALI": {"enabled": True}},
         }
         return base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
 
@@ -49,10 +50,38 @@ class TestAtvpRawBackendParse(unittest.TestCase):
 
     def test_raw_source_skips_secspider_decryption(self):
         self.init_inner(
-            'class Spider:\n    def init(self, extend=""):\n        return None\n'
+            'class Spider:\n    def init(self, extend=""):\n        self.received_extend = extend\n'
         )
 
         self.assertIsNotNone(self.spider._inner)
+        self.assertEqual(
+            json.loads(self.spider._inner.received_extend),
+            {
+                "site": "demo",
+                "token": "demo",
+                "local_proxy_config": "{'ALI': {'enabled': True}}",
+            },
+        )
+
+    def test_source_without_raw_marker_still_uses_secspider_decryption(self):
+        payload = {
+            "api": "https://atv.example",
+            "source": "https://atv.example/plugins/demo/7.txt",
+            "token": "demo",
+        }
+        extend = base64.b64encode(
+            json.dumps(payload, separators=(",", ":")).encode()
+        ).decode()
+        source = 'class Spider:\n    def init(self, extend=""):\n        return None\n'
+
+        with (
+            patch.object(Spider, "_load_source", return_value="encrypted") as load_source,
+            patch.object(Spider, "_decrypt_secspider_source", return_value=source) as decrypt,
+        ):
+            self.spider.init(extend)
+
+        load_source.assert_called_once_with(payload["source"])
+        decrypt.assert_called_once_with("encrypted")
 
     def test_backend_parse_rewrites_category_and_uses_backend_parse_and_play(self):
         source = '''
@@ -88,8 +117,17 @@ class Spider:
         )
         played = self.spider.playerContent("网盘", "1@share", [])
         self.assertEqual(played["url"], "https://video.example/demo.m3u8")
-        self.spider.post.assert_called_once()
-        self.spider.fetch.assert_called_once()
+        self.spider.post.assert_called_once_with(
+            "https://atv.example/parse/demo",
+            json={"url": "https://pan.example/share"},
+            params={"ac": "play"},
+            timeout=10,
+        )
+        self.spider.fetch.assert_called_once_with(
+            "https://atv.example/play/demo",
+            params={"id": "1@share"},
+            timeout=10,
+        )
 
 
 if __name__ == "__main__":

--- a/web-ui/src/views/SubscriptionsView.test.mjs
+++ b/web-ui/src/views/SubscriptionsView.test.mjs
@@ -30,6 +30,10 @@ test('exposes plugin run mode settings in subscription source manager', () => {
   assert.equal(viewSource.includes('Java代理'), true)
 })
 
+test('accepts encrypted txt and raw Python plugin addresses', () => {
+  assert.equal(viewSource.includes('placeholder="https://example.com/plugin.txt 或 plugin.py"'), true)
+})
+
 test('uses visual editor for subscription override instead of raw textarea', () => {
   assert.equal(viewSource.includes('SubscriptionConfigEditor'), true)
   assert.equal(viewSource.includes("openEditor(false)"), true)

--- a/web-ui/src/views/SubscriptionsView.vue
+++ b/web-ui/src/views/SubscriptionsView.vue
@@ -315,7 +315,7 @@
     <el-dialog v-model="pluginVisible" title="订阅源管理" fullscreen>
       <el-form :inline="true" :model="pluginForm">
         <el-form-item label="插件地址" required>
-          <el-input v-model="pluginForm.url" style="width: 460px" placeholder="https://example.com/plugin.txt"/>
+          <el-input v-model="pluginForm.url" style="width: 460px" placeholder="https://example.com/plugin.txt 或 plugin.py"/>
         </el-form-item>
         <el-form-item label="名称">
           <el-input v-model="pluginForm.name" style="width: 180px" placeholder="留空用默认"/>


### PR DESCRIPTION
## Summary
- Support raw Python subscription plugins through `Atvp.py` and `PyProxy` forwarding.
- Preserve encrypted `.txt` spider behavior while enabling `self.backend_parse = True` category/detail/parse/play flows.
- Add Java and Python protocol regression coverage.

## Test Plan
- [x] `mvn test -q`
- [x] `PYTHONPATH=src/main/resources/static python -m unittest discover -s src/test/python -p 'test_Atvp_raw_backend_parse.py' -v`\n- [x] `cd web-ui && npm test`\n- [x] `cd web-ui && npm run build`\n- [x] `git diff --check master...HEAD`