### PR TITLE
添加托管 secspider 插件编译与兼容性校验

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ musl-toolchain/
 /alist-tvbox.yaml
 /config/data/
 /scripts/gh_proxy_bench_result.json
+/work/
 /.claude/worktrees/
 default.conf
 /docs/security/

--- a/docs/managed-secspider-plugin-workflow.md
+++ b/docs/managed-secspider-plugin-workflow.md
@@ -115,6 +115,14 @@ master secret
 
 后端会从 `/data/secspider` 自动读取。
 
+编译前建议先点：
+
+```text
+兼容性校验
+```
+
+它会先跑磁力爬虫门禁，列出不合规项；通过后再点编译，避免把明显不兼容的脚本直接上传进静态仓库。
+
 ## 生成和重置密钥
 
 容器首次启动时会自动生成密钥。
@@ -214,7 +222,7 @@ Atvp spider is not initialized
 后端目标测试：
 
 ```powershell
-.\mvnw.cmd "-Dtest=PluginCompilerServiceTest,PluginCompilerAtvpInteropTest,PluginControllerCompileTest,PluginControllerSecurityTest,SecspiderKeyServiceTest,SelfPluginFileServiceTest" -DfailIfNoTests=false -DforkCount=0 test
+.\mvnw.cmd "-Dtest=PluginCompilerServiceTest,PluginCompilerCompatibilityTest,PluginCompilerAtvpInteropTest,PluginControllerCompileTest,PluginControllerCompatibilityCheckTest,PluginControllerSecurityTest,SecspiderKeyServiceTest,SelfPluginFileServiceTest" -DfailIfNoTests=false -DforkCount=0 test
 ```
 
 前端类型检查：

--- a/docs/managed-secspider-plugin-workflow.md
+++ b/docs/managed-secspider-plugin-workflow.md
@@ -1,0 +1,232 @@
+# 容器托管 secspider 插件编译流程
+
+本文档记录自用三方插件编译的新路径：容器内自动生成 Ed25519 密钥对和 master secret，编译时自动读取，编译成功后自动写入静态插件仓库并导入插件管理。
+
+## 目标
+
+1. 用户不需要手工维护私钥、公钥、master secret。
+2. 密钥文件保存在 Docker 数据卷中，镜像升级不丢失。
+3. `Atvp.py` 运行时从容器配置读取 self keyring，不需要每次改源码回填。
+4. 三方插件编译成功后自动进入本地静态插件仓库。
+5. 编译成功后自动导入插件管理，订阅生成时可直接使用。
+
+## 持久化路径
+
+密钥材料保存到：
+
+```text
+/data/secspider/
+```
+
+具体文件：
+
+```text
+/data/secspider/self-ed25519-private.pem
+/data/secspider/self-ed25519-public.pem
+/data/secspider/self-master-secret.txt
+/data/secspider/atvp-keyring.json
+```
+
+`Atvp.py` 默认读取：
+
+```text
+/data/secspider/atvp-keyring.json
+```
+
+也可以通过环境变量覆盖：
+
+```text
+ATV_SECSPIDER_KEYRING=/path/to/atvp-keyring.json
+```
+
+只要 Docker 运行时保留：
+
+```text
+-v /你的目录/alist-tvbox:/data
+```
+
+这些密钥就会随 `/data` 卷保留，升级镜像不会丢失。
+
+## 静态插件仓库
+
+编译后的插件包自动保存到：
+
+```text
+/www/static/self-plugins/
+```
+
+典型结构：
+
+```text
+/www/static/self-plugins/
+  spiders_v2.json
+  py/
+    javbus_self.txt
+```
+
+外部访问地址：
+
+```text
+http://服务器IP:4567/static/self-plugins/spiders_v2.json
+http://服务器IP:4567/static/self-plugins/py/javbus_self.txt
+```
+
+当前 Docker 运行命令需要保留：
+
+```text
+-v /你的目录/alist-tvbox/www-static:/www/static
+```
+
+这样静态插件仓库也会在升级镜像后保留。
+
+## WebUI 使用方式
+
+路径：
+
+```text
+订阅管理 -> 订阅源管理 -> 三方插件编译
+```
+
+默认开关：
+
+```text
+托管密钥: 使用容器密钥
+自动导入: 编译后导入插件管理
+```
+
+普通使用只需要填写：
+
+```text
+插件名称
+插件版本
+插件 ID
+kid
+remark
+插件明文
+```
+
+不需要填写：
+
+```text
+Ed25519 私钥
+Ed25519 公钥
+master secret
+```
+
+后端会从 `/data/secspider` 自动读取。
+
+## 生成和重置密钥
+
+容器首次启动时会自动生成密钥。
+
+WebUI 也提供两个按钮：
+
+```text
+生成密钥对
+重置密钥对
+```
+
+说明：
+
+1. `生成密钥对`：如果已有密钥，不覆盖；如果缺失，生成。
+2. `重置密钥对`：强制生成新密钥。
+3. 重置后，旧密钥编译出的自有插件无法再被新的 self keyring 解密，需要重新编译。
+4. 原版 stock 插件不受影响。
+
+## 播放链路
+
+编译并导入后，插件管理里会出现新的插件记录。
+
+生成订阅时，插件仍然走项目原有路径：
+
+```text
+csp_PyProxy + spring.jar + base64(ext)
+```
+
+`ext` 内会指向服务端：
+
+```text
+loader: ATV_ADDRESS/Atvp/{token}/{keyringVersion}.py
+source: ATV_ADDRESS/plugins/{token}/{pluginId}.txt
+```
+
+`Atvp.py` 解密时会尝试：
+
+```text
+stock keyring
+self keyring
+```
+
+self keyring 来源优先级：
+
+1. `ATV_SECSPIDER_KEYRING` 环境变量。
+2. `/data/secspider/atvp-keyring.json`。
+3. `/opt/atv/data/secspider/atvp-keyring.json`。
+4. 源码内 `_self_public_key_chunks` / `_self_master_secret_chunks`。
+
+当前推荐使用第 2 种：容器 `/data/secspider/atvp-keyring.json`。
+
+### 默认订阅联调修正
+
+2026-07-17 联调默认订阅路径时发现：`csp_PyProxy` 获取到的 `Atvp.py` 是在 FongMi/TV 客户端内执行，不能直接读取服务端容器里的 `/data/secspider/atvp-keyring.json`。如果只把 keyring 保存到容器本地，但下发的 `Atvp.py` 仍是静态文件，客户端会在 `//@sig` 校验阶段报：
+
+```text
+PyProxy init failed: ValueError: The signature is not authentic
+Atvp spider is not initialized
+```
+
+因此当前实现会在服务端动态渲染 token 化 loader：
+
+```text
+/Atvp/{token}/{keyringVersion}.py
+```
+
+该文件会把容器托管的 `_self_public_key_chunks` 和 `_self_master_secret_chunks` 注入到下发给客户端的 `Atvp.py` 中。`keyringVersion` 由 chunks 计算，重置密钥后 URL 会变化，避免 FongMi 继续使用旧缓存。
+
+排查时要区分三类失败：
+
+1. 订阅未切换：日志仍指向旧域名或旧 token。
+2. 包体损坏：服务端本地用当前 keyring 验签/解密失败。
+3. loader keyring 不匹配：服务端本地验签/解密成功，但客户端报 `The signature is not authentic`。
+
+第 3 类就是本次默认路径的问题，修复点在 loader 下发方式，不在插件包本身。
+
+## 回退方法
+
+如果新密钥或新插件不可用：
+
+1. 在插件管理里禁用或删除刚导入的插件。
+2. 如果只是插件源码问题，保留密钥，重新编译插件。
+3. 如果误重置密钥，只能用新密钥重新编译自有插件。
+4. Docker 镜像可回退到上一个 `sha-*` 标签，但 `/data/secspider` 中的密钥文件不会因为镜像回退自动变化。
+
+## 安全边界
+
+1. 私钥保存在 `/data/secspider/self-ed25519-private.pem`，不进入 Git。
+2. WebUI 不回显私钥和 master secret。
+3. `atvp-keyring.json` 中的 master secret 是混淆 chunks，不是强加密。它的目标是让播放器运行时能解包，而不是抵抗拿到容器文件的人。
+4. 不绕过 Ed25519 签名校验。
+5. 不绕过 SHA256 明文 hash 校验。
+6. 自用插件仓库如果要保密，应保持服务器、镜像、静态目录和插件管理权限私有。
+
+## 验证命令
+
+后端目标测试：
+
+```powershell
+.\mvnw.cmd "-Dtest=PluginCompilerServiceTest,PluginCompilerAtvpInteropTest,PluginControllerCompileTest,PluginControllerSecurityTest,SecspiderKeyServiceTest,SelfPluginFileServiceTest" -DfailIfNoTests=false -DforkCount=0 test
+```
+
+前端类型检查：
+
+```powershell
+cd web-ui
+.\node_modules\.bin\vue-tsc.cmd --noEmit --pretty false
+```
+
+前端构建：
+
+```powershell
+cd web-ui
+.\node_modules\.bin\vite.cmd build
+```

--- a/src/main/java/cn/har01d/alist_tvbox/service/AtvpScriptService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/AtvpScriptService.java
@@ -1,0 +1,60 @@
+package cn.har01d.alist_tvbox.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class AtvpScriptService {
+    private static final Pattern SELF_PUBLIC_KEY_CHUNKS = Pattern.compile(
+            "(?s)(?m)^    _self_public_key_chunks = \\[(?:.*?^    \\]|[^\\n]*\\])"
+    );
+    private static final Pattern SELF_MASTER_SECRET_CHUNKS = Pattern.compile(
+            "(?s)(?m)^    _self_master_secret_chunks = \\[(?:.*?^    \\]|[^\\n]*\\])"
+    );
+
+    private final SecspiderKeyService secspiderKeyService;
+    private final ObjectMapper objectMapper;
+
+    public AtvpScriptService(SecspiderKeyService secspiderKeyService, ObjectMapper objectMapper) {
+        this.secspiderKeyService = secspiderKeyService;
+        this.objectMapper = objectMapper;
+    }
+
+    public String render() throws IOException {
+        String script = readBundledAtvp();
+        SecspiderKeyService.KeyStatus keyStatus = secspiderKeyService.ensureKeyMaterial();
+        script = replaceList(script, SELF_PUBLIC_KEY_CHUNKS, "_self_public_key_chunks", keyStatus.publicKeyChunks());
+        script = replaceList(script, SELF_MASTER_SECRET_CHUNKS, "_self_master_secret_chunks", keyStatus.masterSecretChunks());
+        return script;
+    }
+
+    public String version() {
+        SecspiderKeyService.KeyStatus keyStatus = secspiderKeyService.ensureKeyMaterial();
+        String material = String.join("|", keyStatus.publicKeyChunks())
+                + "\n"
+                + String.join("|", keyStatus.masterSecretChunks());
+        return DigestUtils.sha256Hex(material).substring(0, 12);
+    }
+
+    private String readBundledAtvp() throws IOException {
+        ClassPathResource resource = new ClassPathResource("static/Atvp.py");
+        return new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private String replaceList(String source, Pattern pattern, String name, List<String> values) throws IOException {
+        String replacement = "    " + name + " = " + objectMapper.writeValueAsString(values);
+        String updated = pattern.matcher(source).replaceFirst(Matcher.quoteReplacement(replacement));
+        if (updated.equals(source)) {
+            throw new IOException("Atvp.py missing assignment for " + name);
+        }
+        return updated;
+    }
+}

--- a/src/main/java/cn/har01d/alist_tvbox/service/PluginCompilerService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/PluginCompilerService.java
@@ -3,6 +3,7 @@ package cn.har01d.alist_tvbox.service;
 import cn.har01d.alist_tvbox.exception.BadRequestException;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.Cipher;
@@ -32,6 +33,7 @@ public class PluginCompilerService {
     private static final int PUBLIC_KEY_XOR = 23;
     private static final int MASTER_SECRET_XOR = 41;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private static final Pattern SPIDER_IMPORT_PATTERN = Pattern.compile("(?m)^\\s*from\\s+base\\.spider\\s+import\\s+Spider\\s*$");
     private static final Pattern SPIDER_CLASS_PATTERN = Pattern.compile("(?m)^\\s*class\\s+Spider\\s*\\(\\s*Spider\\s*\\)\\s*:\\s*$");
     private static final Pattern DETAIL_CONTENT_PATTERN = Pattern.compile("(?m)^\\s*def\\s+detailContent\\s*\\(");
@@ -174,7 +176,8 @@ public class PluginCompilerService {
                     (int) passCount,
                     (int) failCount,
                     summary,
-                    items
+                    items,
+                    buildAiRepairExportText(name, pluginId, request.version(), source, source.getBytes(StandardCharsets.UTF_8), passed, summary, items)
             );
         } catch (BadRequestException e) {
             throw e;
@@ -344,6 +347,35 @@ public class PluginCompilerService {
         return new CompatibilityCheckItem(code, title, passed ? "PASS" : "FAIL", message, suggestion);
     }
 
+    private String buildAiRepairExportText(String pluginName,
+                                           String pluginId,
+                                           Integer version,
+                                           String source,
+                                           byte[] sourceBytes,
+                                           boolean passed,
+                                           String summary,
+                                           List<CompatibilityCheckItem> items) throws Exception {
+        List<String> repairSuggestions = items.stream()
+                .filter(item -> "FAIL".equals(item.status()))
+                .map(CompatibilityCheckItem::suggestion)
+                .toList();
+        CompatibilityExportPayload payload = new CompatibilityExportPayload(
+                "AI修复导出",
+                "把错误项需要修改的地方用 AI 更容易理解的方式导出成文本，提交给 AI 修复后再次检查。",
+                "磁力爬虫门禁",
+                pluginName,
+                pluginId,
+                version,
+                sha256Hex(sourceBytes),
+                passed,
+                summary,
+                repairSuggestions,
+                items,
+                source
+        );
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(payload);
+    }
+
     private byte[] buildSigningBytes(SecspiderHeaders headers, String payloadB64) {
         return String.join("\n", signingLines(headers, payloadB64)).getBytes(StandardCharsets.UTF_8);
     }
@@ -480,7 +512,24 @@ public class PluginCompilerService {
             int passCount,
             int failCount,
             String summary,
-            List<CompatibilityCheckItem> items
+            List<CompatibilityCheckItem> items,
+            String aiRepairExportText
+    ) {
+    }
+
+    public record CompatibilityExportPayload(
+            String exportType,
+            String description,
+            String gateName,
+            String pluginName,
+            String pluginId,
+            Integer version,
+            String sourceSha256,
+            boolean passed,
+            String summary,
+            List<String> repairSuggestions,
+            List<CompatibilityCheckItem> items,
+            String source
     ) {
     }
 

--- a/src/main/java/cn/har01d/alist_tvbox/service/PluginCompilerService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/PluginCompilerService.java
@@ -1,0 +1,387 @@
+package cn.har01d.alist_tvbox.service;
+
+import cn.har01d.alist_tvbox.exception.BadRequestException;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.security.spec.EdECPrivateKeySpec;
+import java.security.spec.NamedParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+
+@Service
+public class PluginCompilerService {
+    private static final int PUBLIC_KEY_XOR = 23;
+    private static final int MASTER_SECRET_XOR = 41;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    public CompileResponse compileSecspider(CompileRequest request) {
+        validateRequest(request);
+
+        try {
+            String name = StringUtils.trim(request.name());
+            String version = String.valueOf(request.version());
+            String remark = StringUtils.defaultString(request.remark());
+            String id = StringUtils.trimToEmpty(request.id());
+            String kid = StringUtils.defaultIfBlank(StringUtils.trim(request.kid()), "self");
+            byte[] sourceBytes = request.source().getBytes(StandardCharsets.UTF_8);
+            byte[] masterSecret = request.masterSecret().getBytes(StandardCharsets.UTF_8);
+            PrivateKey privateKey = parseEd25519PrivateKey(request.privateKey());
+            PublicKey publicKey = StringUtils.isBlank(request.publicKey()) ? null : parseEd25519PublicKey(request.publicKey());
+
+            byte[] contentKey = randomBytes(32);
+            byte[] payloadNonce = randomBytes(12);
+            byte[] payloadBlob = aesGcmEncrypt(contentKey, payloadNonce, sourceBytes);
+
+            byte[] wrapKey = hkdf(masterSecret, kid.getBytes(StandardCharsets.UTF_8),
+                    ("secspider:" + name + ":" + version + ":wrap-key").getBytes(StandardCharsets.UTF_8), 32);
+            byte[] wrapNonce = hkdf(masterSecret, kid.getBytes(StandardCharsets.UTF_8),
+                    ("secspider:" + name + ":" + version + ":wrap-nonce").getBytes(StandardCharsets.UTF_8), 12);
+            byte[] wrappedKey = aesGcmEncrypt(wrapKey, wrapNonce, contentKey);
+
+            String payloadB64 = Base64.getEncoder().encodeToString(payloadBlob);
+            String sourceHash = sha256Hex(sourceBytes);
+            SecspiderHeaders headers = new SecspiderHeaders(
+                    name,
+                    version,
+                    remark,
+                    id,
+                    "secspider/1",
+                    "aes-256-gcm",
+                    "hkdf-aes-keywrap",
+                    "ed25519",
+                    kid,
+                    "base64:" + Base64.getEncoder().encodeToString(payloadNonce),
+                    "base64:" + Base64.getEncoder().encodeToString(wrappedKey),
+                    "sha256:" + sourceHash
+            );
+
+            byte[] signingBytes = buildSigningBytes(headers, payloadB64);
+            byte[] signature = signEd25519(privateKey, signingBytes);
+            if (publicKey != null && !verifyEd25519(publicKey, signingBytes, signature)) {
+                throw new BadRequestException("Ed25519 公钥与私钥不匹配");
+            }
+            String packageText = buildPackageText(headers, "base64:" + Base64.getEncoder().encodeToString(signature), payloadB64);
+
+            List<String> publicKeyChunks = publicKey == null
+                    ? List.of()
+                    : obfuscateText(toPem("PUBLIC KEY", publicKey.getEncoded()), PUBLIC_KEY_XOR, 16);
+            List<String> masterSecretChunks = obfuscateText(request.masterSecret(), MASTER_SECRET_XOR, 16);
+
+            return new CompileResponse(
+                    packageText,
+                    sourceHash,
+                    packageText.getBytes(StandardCharsets.UTF_8).length,
+                    "secspider/1",
+                    "aes-256-gcm",
+                    "hkdf-aes-keywrap",
+                    "ed25519",
+                    kid,
+                    publicKeyChunks,
+                    masterSecretChunks,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        } catch (BadRequestException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BadRequestException("插件编译失败: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateRequest(CompileRequest request) {
+        if (request == null) {
+            throw new BadRequestException("请求不能为空");
+        }
+        if (StringUtils.isBlank(request.name())) {
+            throw new BadRequestException("插件名称不能为空");
+        }
+        validateHeaderValue("插件名称", request.name());
+        if (request.version() == null || request.version() < 1) {
+            throw new BadRequestException("插件版本必须大于 0");
+        }
+        validateHeaderValue("remark", request.remark());
+        validateHeaderValue("插件 ID", request.id());
+        validateHeaderValue("kid", request.kid());
+        if (StringUtils.isBlank(request.source())) {
+            throw new BadRequestException("插件明文不能为空");
+        }
+        if (StringUtils.isBlank(request.privateKey())) {
+            throw new BadRequestException("Ed25519 私钥不能为空");
+        }
+        if (StringUtils.isBlank(request.masterSecret())) {
+            throw new BadRequestException("master secret 不能为空");
+        }
+    }
+
+    private void validateHeaderValue(String label, String value) {
+        if (value != null && (value.contains("\n") || value.contains("\r"))) {
+            throw new BadRequestException(label + "不能包含换行");
+        }
+    }
+
+    private byte[] randomBytes(int length) {
+        byte[] bytes = new byte[length];
+        SECURE_RANDOM.nextBytes(bytes);
+        return bytes;
+    }
+
+    private PrivateKey parseEd25519PrivateKey(String input) throws Exception {
+        byte[] keyBytes = decodeKeyMaterial(input);
+        KeyFactory keyFactory = KeyFactory.getInstance("Ed25519");
+        try {
+            return keyFactory.generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
+        } catch (Exception ignored) {
+            if (keyBytes.length != 32) {
+                throw new BadRequestException("Ed25519 私钥需为 PKCS8 PEM/base64，或 32 字节 raw seed");
+            }
+            return keyFactory.generatePrivate(new EdECPrivateKeySpec(NamedParameterSpec.ED25519, keyBytes));
+        }
+    }
+
+    private PublicKey parseEd25519PublicKey(String input) throws Exception {
+        byte[] keyBytes = decodeKeyMaterial(input);
+        try {
+            return KeyFactory.getInstance("Ed25519").generatePublic(new X509EncodedKeySpec(keyBytes));
+        } catch (Exception e) {
+            throw new BadRequestException("Ed25519 公钥需为 X509 PEM/base64", e);
+        }
+    }
+
+    private byte[] decodeKeyMaterial(String input) {
+        String value = StringUtils.trimToEmpty(input);
+        if (value.contains("-----BEGIN")) {
+            value = value.replaceAll("-----BEGIN [^-]+-----", "")
+                    .replaceAll("-----END [^-]+-----", "")
+                    .replaceAll("\\s+", "");
+            return Base64.getDecoder().decode(value);
+        }
+        String compact = value.replaceAll("\\s+", "");
+        if (compact.matches("(?i)^[0-9a-f]{64}$")) {
+            return HexFormat.of().parseHex(compact);
+        }
+        return Base64.getDecoder().decode(compact);
+    }
+
+    private String toPem(String type, byte[] bytes) {
+        return "-----BEGIN " + type + "-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(bytes)
+                + "\n-----END " + type + "-----";
+    }
+
+    private byte[] aesGcmEncrypt(byte[] key, byte[] nonce, byte[] plaintext) throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(128, nonce));
+        return cipher.doFinal(plaintext);
+    }
+
+    private byte[] hkdf(byte[] master, byte[] salt, byte[] info, int length) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(salt, "HmacSHA256"));
+        byte[] prk = mac.doFinal(master);
+
+        byte[] result = new byte[length];
+        byte[] previous = new byte[0];
+        int offset = 0;
+        int counter = 1;
+        while (offset < length) {
+            mac.init(new SecretKeySpec(prk, "HmacSHA256"));
+            mac.update(previous);
+            mac.update(info);
+            mac.update((byte) counter);
+            previous = mac.doFinal();
+            int copy = Math.min(previous.length, length - offset);
+            System.arraycopy(previous, 0, result, offset, copy);
+            offset += copy;
+            counter++;
+        }
+        return result;
+    }
+
+    private String sha256Hex(byte[] bytes) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+    }
+
+    private byte[] signEd25519(PrivateKey privateKey, byte[] data) throws Exception {
+        Signature signature = Signature.getInstance("Ed25519");
+        signature.initSign(privateKey);
+        signature.update(data);
+        return signature.sign();
+    }
+
+    private boolean verifyEd25519(PublicKey publicKey, byte[] data, byte[] signatureBytes) throws Exception {
+        Signature signature = Signature.getInstance("Ed25519");
+        signature.initVerify(publicKey);
+        signature.update(data);
+        return signature.verify(signatureBytes);
+    }
+
+    private byte[] buildSigningBytes(SecspiderHeaders headers, String payloadB64) {
+        return String.join("\n", signingLines(headers, payloadB64)).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private List<String> signingLines(SecspiderHeaders headers, String payloadB64) {
+        List<String> lines = new ArrayList<>();
+        lines.add("//@name:" + headers.name());
+        lines.add("//@version:" + headers.version());
+        lines.add("//@remark:" + headers.remark());
+        if (StringUtils.isNotBlank(headers.id())) {
+            lines.add("//@id:" + headers.id());
+        }
+        lines.add("//@format:" + headers.format());
+        lines.add("//@alg:" + headers.alg());
+        lines.add("//@wrap:" + headers.wrap());
+        lines.add("//@sign:" + headers.sign());
+        lines.add("//@kid:" + headers.kid());
+        lines.add("//@nonce:" + headers.nonce());
+        lines.add("//@ek:" + headers.ek());
+        lines.add("//@hash:" + headers.hash());
+        lines.add("payload.base64:" + payloadB64);
+        return lines;
+    }
+
+    private String buildPackageText(SecspiderHeaders headers, String signature, String payloadB64) {
+        List<String> lines = new ArrayList<>();
+        lines.add("//@name:" + headers.name());
+        lines.add("//@version:" + headers.version());
+        lines.add("//@remark:" + headers.remark());
+        if (StringUtils.isNotBlank(headers.id())) {
+            lines.add("//@id:" + headers.id());
+        }
+        lines.add("//@format:" + headers.format());
+        lines.add("//@alg:" + headers.alg());
+        lines.add("//@wrap:" + headers.wrap());
+        lines.add("//@sign:" + headers.sign());
+        lines.add("//@kid:" + headers.kid());
+        lines.add("//@nonce:" + headers.nonce());
+        lines.add("//@ek:" + headers.ek());
+        lines.add("//@hash:" + headers.hash());
+        lines.add("//@sig:" + signature);
+        lines.add("");
+        lines.add("payload.base64:" + payloadB64);
+        return String.join("\n", lines) + "\n";
+    }
+
+    private List<String> obfuscateText(String text, int xorKey, int chunkSize) {
+        byte[] raw = text.getBytes(StandardCharsets.UTF_8);
+        List<String> chunks = new ArrayList<>();
+        for (int index = 0; index < raw.length; index += chunkSize) {
+            int end = Math.min(index + chunkSize, raw.length);
+            byte[] chunk = ByteBuffer.allocate(end - index).put(raw, index, end - index).array();
+            for (int i = 0; i < chunk.length; i++) {
+                chunk[i] = (byte) (chunk[i] ^ xorKey);
+            }
+            chunks.add(Base64.getEncoder().encodeToString(chunk));
+        }
+        List<String> reversed = new ArrayList<>();
+        for (int index = chunks.size() - 1; index >= 0; index--) {
+            reversed.add(chunks.get(index));
+        }
+        return reversed;
+    }
+
+    private record SecspiderHeaders(
+            String name,
+            String version,
+            String remark,
+            String id,
+            String format,
+            String alg,
+            String wrap,
+            String sign,
+            String kid,
+            String nonce,
+            String ek,
+            String hash
+    ) {
+    }
+
+    public record CompileRequest(
+            String name,
+            Integer version,
+            String remark,
+            String id,
+            String kid,
+            String source,
+            String privateKey,
+            String publicKey,
+            String masterSecret,
+            Boolean useManagedKey,
+            Boolean autoImport
+    ) {
+        public CompileRequest(
+                String name,
+                Integer version,
+                String remark,
+                String id,
+                String kid,
+                String source,
+                String privateKey,
+                String publicKey,
+                String masterSecret
+        ) {
+            this(name, version, remark, id, kid, source, privateKey, publicKey, masterSecret, null, null);
+        }
+    }
+
+    public record CompileResponse(
+            String packageText,
+            String plainSha256,
+            int packageSize,
+            String format,
+            String alg,
+            String wrap,
+            String sign,
+            String kid,
+            List<String> publicKeyChunks,
+            List<String> masterSecretChunks,
+            Integer importedPluginId,
+            String importedPluginName,
+            String pluginUrl,
+            String repositoryUrl,
+            String localPath
+    ) {
+        public CompileResponse withImportedPlugin(Integer importedPluginId,
+                                                  String importedPluginName,
+                                                  String pluginUrl,
+                                                  String repositoryUrl,
+                                                  String localPath) {
+            return new CompileResponse(
+                    packageText,
+                    plainSha256,
+                    packageSize,
+                    format,
+                    alg,
+                    wrap,
+                    sign,
+                    kid,
+                    publicKeyChunks,
+                    masterSecretChunks,
+                    importedPluginId,
+                    importedPluginName,
+                    pluginUrl,
+                    repositoryUrl,
+                    localPath
+            );
+        }
+    }
+}

--- a/src/main/java/cn/har01d/alist_tvbox/service/PluginCompilerService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/PluginCompilerService.java
@@ -1,6 +1,7 @@
 package cn.har01d.alist_tvbox.service;
 
 import cn.har01d.alist_tvbox.exception.BadRequestException;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
@@ -24,12 +25,22 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Service
 public class PluginCompilerService {
     private static final int PUBLIC_KEY_XOR = 23;
     private static final int MASTER_SECRET_XOR = 41;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final Pattern SPIDER_IMPORT_PATTERN = Pattern.compile("(?m)^\\s*from\\s+base\\.spider\\s+import\\s+Spider\\s*$");
+    private static final Pattern SPIDER_CLASS_PATTERN = Pattern.compile("(?m)^\\s*class\\s+Spider\\s*\\(\\s*Spider\\s*\\)\\s*:\\s*$");
+    private static final Pattern DETAIL_CONTENT_PATTERN = Pattern.compile("(?m)^\\s*def\\s+detailContent\\s*\\(");
+    private static final Pattern PLAYER_CONTENT_PATTERN = Pattern.compile("(?m)^\\s*def\\s+playerContent\\s*\\(");
+    private static final Pattern VOD_PIC_PATTERN = Pattern.compile("\\bvod_pic\\b");
+    private static final Pattern VOD_PLAY_FROM_PATTERN = Pattern.compile("\\bvod_play_from\\b");
+    private static final Pattern VOD_PLAY_URL_PATTERN = Pattern.compile("\\bvod_play_url\\b");
+    private static final Pattern MAGNET_FLOW_PATTERN = Pattern.compile("(?i)magnet:|btih");
+    private static final Pattern OUTER_HEADER_PATTERN = Pattern.compile("(?m)^\\s*//@");
 
     public CompileResponse compileSecspider(CompileRequest request) {
         validateRequest(request);
@@ -108,6 +119,70 @@ public class PluginCompilerService {
         }
     }
 
+    public CompatibilityCheckResponse checkMagnetSpiderCompatibility(CompatibilityCheckRequest request) {
+        validateCompatibilityRequest(request);
+
+        try {
+            String name = StringUtils.trim(request.name());
+            String id = StringUtils.trimToEmpty(request.id());
+            String pluginId = StringUtils.defaultIfBlank(id, derivePluginId(name));
+            String source = StringUtils.defaultString(request.source());
+            List<CompatibilityCheckItem> items = new ArrayList<>();
+
+            items.add(checkItem("outer_headers", "内层明文包头", !OUTER_HEADER_PATTERN.matcher(source).find(),
+                    "内层明文未混入 //@ 包头",
+                    "如果这是 secspider 外层包体，请把外层头部移到包体生成器里，内层只保留 Python 源码"));
+            items.add(checkItem("base_spider_import", "Spider 导入", SPIDER_IMPORT_PATTERN.matcher(source).find(),
+                    "已包含 from base.spider import Spider",
+                    "保留 AList-TVBox 的 Spider 基类导入"));
+            items.add(checkItem("spider_class", "Spider 类定义", SPIDER_CLASS_PATTERN.matcher(source).find(),
+                    "已包含 class Spider(Spider):",
+                    "保留 Spider(Spider) 继承声明"));
+            items.add(checkItem("detail_content", "详情入口", DETAIL_CONTENT_PATTERN.matcher(source).find(),
+                    "已包含 detailContent",
+                    "确保详情页能够返回磁链卡片与封面图"));
+            items.add(checkItem("player_content", "播放入口", PLAYER_CONTENT_PATTERN.matcher(source).find(),
+                    "已包含 playerContent",
+                    "确保播放时能进入插件内部解析流程"));
+            items.add(checkItem("vod_pic", "封面字段", VOD_PIC_PATTERN.matcher(source).find(),
+                    "已包含 vod_pic",
+                    "详情和选片卡片应保留封面图"));
+            items.add(checkItem("vod_play_from", "播放分组", VOD_PLAY_FROM_PATTERN.matcher(source).find(),
+                    "已包含 vod_play_from",
+                    "保留播放分组，避免详情页被压扁成纯文本"));
+            items.add(checkItem("vod_play_url", "播放列表", VOD_PLAY_URL_PATTERN.matcher(source).find(),
+                    "已包含 vod_play_url",
+                    "保留播放列表，确保卡片能绑定到具体磁链"));
+            items.add(checkItem("magnet_flow", "磁力链标记", MAGNET_FLOW_PATTERN.matcher(source).find(),
+                    "已检测到 magnet / btih 相关标记",
+                    "磁力爬虫门禁需要能看见磁力链处理路径"));
+
+            long failCount = items.stream().filter(item -> "FAIL".equals(item.status())).count();
+            long passCount = items.size() - failCount;
+            boolean passed = failCount == 0;
+            String summary = passed
+                    ? "磁力爬虫门禁通过"
+                    : "磁力爬虫门禁未通过：" + failCount + " 项不合规";
+
+            return new CompatibilityCheckResponse(
+                    "磁力爬虫门禁",
+                    name,
+                    pluginId,
+                    request.version(),
+                    sha256Hex(source.getBytes(StandardCharsets.UTF_8)),
+                    passed,
+                    (int) passCount,
+                    (int) failCount,
+                    summary,
+                    items
+            );
+        } catch (BadRequestException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BadRequestException("兼容性校验失败: " + e.getMessage(), e);
+        }
+    }
+
     private void validateRequest(CompileRequest request) {
         if (request == null) {
             throw new BadRequestException("请求不能为空");
@@ -130,6 +205,24 @@ public class PluginCompilerService {
         }
         if (StringUtils.isBlank(request.masterSecret())) {
             throw new BadRequestException("master secret 不能为空");
+        }
+    }
+
+    private void validateCompatibilityRequest(CompatibilityCheckRequest request) {
+        if (request == null) {
+            throw new BadRequestException("请求不能为空");
+        }
+        if (StringUtils.isBlank(request.name())) {
+            throw new BadRequestException("插件名称不能为空");
+        }
+        validateHeaderValue("插件名称", request.name());
+        if (request.version() == null || request.version() < 1) {
+            throw new BadRequestException("插件版本必须大于 0");
+        }
+        validateHeaderValue("remark", request.remark());
+        validateHeaderValue("插件 ID", request.id());
+        if (StringUtils.isBlank(request.source())) {
+            throw new BadRequestException("插件明文不能为空");
         }
     }
 
@@ -233,6 +326,22 @@ public class PluginCompilerService {
         signature.initVerify(publicKey);
         signature.update(data);
         return signature.verify(signatureBytes);
+    }
+
+    private String derivePluginId(String name) {
+        String normalized = StringUtils.defaultString(name)
+                .trim()
+                .toLowerCase()
+                .replaceAll("[^a-z0-9_.-]+", "_")
+                .replaceAll("^_+|_+$", "");
+        if (StringUtils.isNotBlank(normalized)) {
+            return normalized.length() > 80 ? normalized.substring(0, 80) : normalized;
+        }
+        return "plugin_" + DigestUtils.sha256Hex(StringUtils.defaultString(name)).substring(0, 12);
+    }
+
+    private CompatibilityCheckItem checkItem(String code, String title, boolean passed, String message, String suggestion) {
+        return new CompatibilityCheckItem(code, title, passed ? "PASS" : "FAIL", message, suggestion);
     }
 
     private byte[] buildSigningBytes(SecspiderHeaders headers, String payloadB64) {
@@ -341,6 +450,38 @@ public class PluginCompilerService {
         ) {
             this(name, version, remark, id, kid, source, privateKey, publicKey, masterSecret, null, null);
         }
+    }
+
+    public record CompatibilityCheckRequest(
+            String name,
+            Integer version,
+            String remark,
+            String id,
+            String source
+    ) {
+    }
+
+    public record CompatibilityCheckItem(
+            String code,
+            String title,
+            String status,
+            String message,
+            String suggestion
+    ) {
+    }
+
+    public record CompatibilityCheckResponse(
+            String gateName,
+            String pluginName,
+            String pluginId,
+            Integer version,
+            String sourceSha256,
+            boolean passed,
+            int passCount,
+            int failCount,
+            String summary,
+            List<CompatibilityCheckItem> items
+    ) {
     }
 
     public record CompileResponse(

--- a/src/main/java/cn/har01d/alist_tvbox/service/PluginService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/PluginService.java
@@ -104,6 +104,41 @@ public class PluginService {
     }
 
     @Transactional
+    public Plugin upsertCompiledPlugin(String url,
+                                       String localPath,
+                                       String externalId,
+                                       String sourceName,
+                                       Integer version,
+                                       String packageText) {
+        Plugin plugin = findExistingPlugin(url, externalId);
+        boolean created = plugin == null;
+        if (created) {
+            plugin = new Plugin();
+            plugin.setEnabled(true);
+            plugin.setSortOrder(subscriptionSourceService.nextSortOrder());
+        } else {
+            validateUrlUniqueness(url, plugin.getId());
+            validateExternalIdUniqueness(externalId, plugin.getId());
+        }
+
+        plugin.setUrl(url);
+        plugin.setLocalPath(localPath);
+        plugin.setExternalId(StringUtils.trimToNull(externalId));
+        plugin.setSourceName(StringUtils.defaultIfBlank(sourceName, externalId));
+        plugin.setName(StringUtils.defaultIfBlank(plugin.getName(), plugin.getSourceName()));
+        plugin.setVersion(version);
+        plugin.setContent(packageText);
+        plugin.setLastCheckedAt(OffsetDateTime.now());
+        plugin.setLastError("");
+
+        if (created) {
+            validateUrlUniqueness(plugin.getUrl(), null);
+            validateExternalIdUniqueness(plugin.getExternalId(), null);
+        }
+        return pluginRepository.save(plugin);
+    }
+
+    @Transactional
     public Plugin update(Integer id, Plugin input) {
         Plugin plugin = pluginRepository.findById(id).orElseThrow(NotFoundException::new);
         boolean urlChanged = !StringUtils.equals(plugin.getUrl(), input.getUrl());

--- a/src/main/java/cn/har01d/alist_tvbox/service/SecspiderKeyService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/SecspiderKeyService.java
@@ -1,0 +1,217 @@
+package cn.har01d.alist_tvbox.service;
+
+import cn.har01d.alist_tvbox.exception.BadRequestException;
+import cn.har01d.alist_tvbox.util.Utils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.security.spec.NamedParameterSpec;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Service
+public class SecspiderKeyService {
+    private static final int PUBLIC_KEY_XOR = 23;
+    private static final int MASTER_SECRET_XOR = 41;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final ObjectMapper objectMapper;
+
+    public SecspiderKeyService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        try {
+            ensureKeyMaterial();
+        } catch (Exception e) {
+            log.warn("failed to initialize secspider key material", e);
+        }
+    }
+
+    public synchronized KeyStatus ensureKeyMaterial() {
+        if (!hasKeyMaterial()) {
+            return generateKeyMaterial(false);
+        }
+        return status();
+    }
+
+    public synchronized KeyStatus status() {
+        try {
+            ensureKeyringFile();
+            String publicKey = Files.readString(publicKeyPath(), StandardCharsets.UTF_8);
+            String masterSecret = Files.readString(masterSecretPath(), StandardCharsets.UTF_8).trim();
+            return new KeyStatus(
+                    true,
+                    privateKeyPath().toString(),
+                    publicKeyPath().toString(),
+                    masterSecretPath().toString(),
+                    keyringPath().toString(),
+                    publicKey,
+                    obfuscateText(publicKey, PUBLIC_KEY_XOR, 16),
+                    obfuscateText(masterSecret, MASTER_SECRET_XOR, 16)
+            );
+        } catch (IOException e) {
+            throw new BadRequestException("secspider 密钥读取失败: " + e.getMessage(), e);
+        }
+    }
+
+    public synchronized KeyStatus generateKeyMaterial(boolean overwrite) {
+        if (!overwrite && hasKeyMaterial()) {
+            return status();
+        }
+        try {
+            Files.createDirectories(baseDir());
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("Ed25519");
+            generator.initialize(NamedParameterSpec.ED25519);
+            KeyPair keyPair = generator.generateKeyPair();
+
+            String privateKey = toPem("PRIVATE KEY", keyPair.getPrivate().getEncoded());
+            String publicKey = toPem("PUBLIC KEY", keyPair.getPublic().getEncoded());
+            String masterSecret = "self-master-" + HexFormat.of().formatHex(randomBytes(32));
+
+            Files.writeString(privateKeyPath(), privateKey, StandardCharsets.UTF_8);
+            Files.writeString(publicKeyPath(), publicKey, StandardCharsets.UTF_8);
+            Files.writeString(masterSecretPath(), masterSecret + "\n", StandardCharsets.UTF_8);
+            writeKeyringFile(publicKey, masterSecret);
+            restrictOwnerOnly(privateKeyPath());
+            restrictOwnerOnly(masterSecretPath());
+            log.info("generated secspider key material at {}", baseDir());
+            return status();
+        } catch (Exception e) {
+            throw new BadRequestException("secspider 密钥生成失败: " + e.getMessage(), e);
+        }
+    }
+
+    public CompilerKeyMaterial compilerKeyMaterial() {
+        ensureKeyMaterial();
+        try {
+            return new CompilerKeyMaterial(
+                    Files.readString(privateKeyPath(), StandardCharsets.UTF_8),
+                    Files.readString(publicKeyPath(), StandardCharsets.UTF_8),
+                    Files.readString(masterSecretPath(), StandardCharsets.UTF_8).trim()
+            );
+        } catch (IOException e) {
+            throw new BadRequestException("secspider 密钥读取失败: " + e.getMessage(), e);
+        }
+    }
+
+    private boolean hasKeyMaterial() {
+        return Files.isRegularFile(privateKeyPath())
+                && Files.isRegularFile(publicKeyPath())
+                && Files.isRegularFile(masterSecretPath());
+    }
+
+    private void ensureKeyringFile() throws IOException {
+        if (!hasKeyMaterial()) {
+            return;
+        }
+        String publicKey = Files.readString(publicKeyPath(), StandardCharsets.UTF_8);
+        String masterSecret = Files.readString(masterSecretPath(), StandardCharsets.UTF_8).trim();
+        writeKeyringFile(publicKey, masterSecret);
+    }
+
+    private void writeKeyringFile(String publicKey, String masterSecret) throws IOException {
+        Files.createDirectories(baseDir());
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(keyringPath().toFile(), Map.of(
+                "format", "atvp-secspider-keyring/1",
+                "updatedAt", OffsetDateTime.now().toString(),
+                "publicKeyChunks", obfuscateText(publicKey, PUBLIC_KEY_XOR, 16),
+                "masterSecretChunks", obfuscateText(masterSecret, MASTER_SECRET_XOR, 16)
+        ));
+    }
+
+    private Path baseDir() {
+        return Utils.getDataPath("secspider");
+    }
+
+    private Path privateKeyPath() {
+        return baseDir().resolve("self-ed25519-private.pem");
+    }
+
+    private Path publicKeyPath() {
+        return baseDir().resolve("self-ed25519-public.pem");
+    }
+
+    private Path masterSecretPath() {
+        return baseDir().resolve("self-master-secret.txt");
+    }
+
+    private Path keyringPath() {
+        return baseDir().resolve("atvp-keyring.json");
+    }
+
+    private byte[] randomBytes(int length) {
+        byte[] bytes = new byte[length];
+        SECURE_RANDOM.nextBytes(bytes);
+        return bytes;
+    }
+
+    private String toPem(String type, byte[] bytes) {
+        return "-----BEGIN " + type + "-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(bytes)
+                + "\n-----END " + type + "-----\n";
+    }
+
+    private List<String> obfuscateText(String text, int xorKey, int chunkSize) {
+        byte[] raw = text.getBytes(StandardCharsets.UTF_8);
+        List<String> chunks = new ArrayList<>();
+        for (int index = 0; index < raw.length; index += chunkSize) {
+            int end = Math.min(index + chunkSize, raw.length);
+            byte[] chunk = ByteBuffer.allocate(end - index).put(raw, index, end - index).array();
+            for (int i = 0; i < chunk.length; i++) {
+                chunk[i] = (byte) (chunk[i] ^ xorKey);
+            }
+            chunks.add(Base64.getEncoder().encodeToString(chunk));
+        }
+        List<String> reversed = new ArrayList<>();
+        for (int index = chunks.size() - 1; index >= 0; index--) {
+            reversed.add(chunks.get(index));
+        }
+        return reversed;
+    }
+
+    private void restrictOwnerOnly(Path path) {
+        try {
+            Files.setPosixFilePermissions(path, Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE
+            ));
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Windows and some filesystems do not support POSIX permissions.
+        }
+    }
+
+    public record CompilerKeyMaterial(String privateKey, String publicKey, String masterSecret) {
+    }
+
+    public record KeyStatus(
+            boolean generated,
+            String privateKeyPath,
+            String publicKeyPath,
+            String masterSecretPath,
+            String keyringPath,
+            String publicKey,
+            List<String> publicKeyChunks,
+            List<String> masterSecretChunks
+    ) {
+    }
+}

--- a/src/main/java/cn/har01d/alist_tvbox/service/SelfPluginFileService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/SelfPluginFileService.java
@@ -1,0 +1,118 @@
+package cn.har01d.alist_tvbox.service;
+
+import cn.har01d.alist_tvbox.exception.BadRequestException;
+import cn.har01d.alist_tvbox.util.Utils;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class SelfPluginFileService {
+    private static final String REPOSITORY_DIR = "self-plugins";
+    private static final String PLUGIN_DIR = "py";
+    private static final String INDEX_FILE = "spiders_v2.json";
+
+    private final ObjectMapper objectMapper;
+
+    public SelfPluginFileService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public StoredPlugin store(String pluginId, Integer version, String packageText, String contextPath) {
+        String safeId = safePluginId(pluginId);
+        try {
+            Path repoDir = repositoryPath();
+            Path pluginDir = repoDir.resolve(PLUGIN_DIR);
+            Files.createDirectories(pluginDir);
+
+            Path pluginPath = pluginDir.resolve(safeId + ".txt");
+            Files.writeString(pluginPath, packageText, StandardCharsets.UTF_8);
+            upsertIndexEntry(safeId, version == null ? 1 : version);
+
+            String relativeFile = REPOSITORY_DIR + "/" + PLUGIN_DIR + "/" + safeId + ".txt";
+            String relativeIndex = REPOSITORY_DIR + "/" + INDEX_FILE;
+            String base = StringUtils.removeEnd(StringUtils.defaultString(contextPath), "/");
+            return new StoredPlugin(
+                    "/static/" + relativeFile,
+                    "/static/" + relativeIndex,
+                    base + "/static/" + relativeFile,
+                    base + "/static/" + relativeIndex,
+                    pluginPath.toString()
+            );
+        } catch (IOException e) {
+            throw new BadRequestException("自用插件仓库写入失败: " + e.getMessage(), e);
+        }
+    }
+
+    private void upsertIndexEntry(String pluginId, Integer version) throws IOException {
+        Path indexPath = repositoryPath().resolve(INDEX_FILE);
+        List<Map<String, Object>> entries = readIndex(indexPath);
+        String file = PLUGIN_DIR + "/" + pluginId + ".txt";
+
+        boolean updated = false;
+        for (Map<String, Object> entry : entries) {
+            if (pluginId.equals(entry.get("id"))) {
+                entry.put("file", file);
+                entry.put("version", version);
+                entry.put("valid", true);
+                updated = true;
+                break;
+            }
+        }
+        if (!updated) {
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("id", pluginId);
+            entry.put("file", file);
+            entry.put("version", version);
+            entry.put("valid", true);
+            entries.add(entry);
+        }
+
+        objectMapper.writerWithDefaultPrettyPrinter().writeValue(indexPath.toFile(), entries);
+    }
+
+    private List<Map<String, Object>> readIndex(Path indexPath) throws IOException {
+        if (!Files.isRegularFile(indexPath)) {
+            return new ArrayList<>();
+        }
+        return new ArrayList<>(objectMapper.readValue(
+                Files.readString(indexPath, StandardCharsets.UTF_8),
+                new TypeReference<List<Map<String, Object>>>() {
+                }
+        ));
+    }
+
+    private Path repositoryPath() {
+        return Utils.getWebPath("static", REPOSITORY_DIR);
+    }
+
+    private String safePluginId(String pluginId) {
+        String value = StringUtils.trimToNull(pluginId);
+        if (value == null) {
+            throw new BadRequestException("插件 ID 不能为空");
+        }
+        if (!value.matches("[A-Za-z0-9_.-]{1,80}")) {
+            throw new BadRequestException("插件 ID 只能包含字母、数字、点、下划线和短横线");
+        }
+        return value;
+    }
+
+    public record StoredPlugin(
+            String relativePluginUrl,
+            String relativeRepositoryUrl,
+            String pluginUrl,
+            String repositoryUrl,
+            String localPath
+    ) {
+    }
+}

--- a/src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/SubscriptionService.java
@@ -111,6 +111,7 @@ public class SubscriptionService {
     private final UserService userService;
     private final FileDownloader fileDownloader;
     private final SubscriptionSourceService subscriptionSourceService;
+    private final AtvpScriptService atvpScriptService;
 
     private final OkHttpClient okHttpClient = new OkHttpClient();
     private final ThreadLocal<String> currentToken = new ThreadLocal<>();
@@ -138,7 +139,8 @@ public class SubscriptionService {
                                TenantService tenantService,
                                UserService userService,
                                FileDownloader fileDownloader,
-                               SubscriptionSourceService subscriptionSourceService) {
+                               SubscriptionSourceService subscriptionSourceService,
+                               AtvpScriptService atvpScriptService) {
         this.environment = environment;
         this.appProperties = appProperties;
         this.restTemplate = builder
@@ -164,6 +166,7 @@ public class SubscriptionService {
         this.userService = userService;
         this.fileDownloader = fileDownloader;
         this.subscriptionSourceService = subscriptionSourceService;
+        this.atvpScriptService = atvpScriptService;
     }
 
     @PostConstruct
@@ -1467,7 +1470,8 @@ public class SubscriptionService {
         site.put("changeable", 0);
         String url = readHostAddress("");
         boolean nativePython = isNativePythonPluginRunMode();
-        site.put("api", selectPluginApi(plugin, nativePython, url));
+        String atvpLoader = buildAtvpLoaderUrl(url, token);
+        site.put("api", PluginService.isPythonPluginUrl(plugin.getUrl()) ? "csp_PyProxy" : nativePython ? atvpLoader : "csp_PyProxy");
         site.put("type", 3);
         site.put("key", plugin.getName());
         site.put("searchable", 1);
@@ -1487,6 +1491,7 @@ public class SubscriptionService {
                 nativePython,
                 readLocalProxyConfig()
         );
+        map.put("loader", atvpLoader);
         // 每个插件站点只下发与自己作用域匹配的过滤器
         List<Map<String, Object>> filters = buildPluginFilters(plugin);
         if (!filters.isEmpty()) {
@@ -1496,6 +1501,11 @@ public class SubscriptionService {
         ext = Base64.getEncoder().encodeToString(ext.getBytes());
         site.put("ext", ext);
         return site;
+    }
+
+    private String buildAtvpLoaderUrl(String baseUrl, String token) {
+        String loaderToken = StringUtils.defaultIfBlank(token, getCurrentOrFirstToken());
+        return baseUrl + "/Atvp/" + loaderToken + "/" + atvpScriptService.version() + ".py";
     }
 
     private List<Map<String, Object>> buildPluginFilters(Plugin plugin) {

--- a/src/main/java/cn/har01d/alist_tvbox/util/Utils.java
+++ b/src/main/java/cn/har01d/alist_tvbox/util/Utils.java
@@ -389,7 +389,10 @@ public final class Utils {
     }
 
     public static Path getWebPath(String... path) {
-        String base = inDocker ? "/www" : "/opt/atv/www";
+        String base = System.getProperty("atv.web.dir");
+        if (StringUtils.isBlank(base)) {
+            base = inDocker ? "/www" : "/opt/atv/www";
+        }
         return Path.of(base, path);
     }
 

--- a/src/main/java/cn/har01d/alist_tvbox/web/AtvpScriptController.java
+++ b/src/main/java/cn/har01d/alist_tvbox/web/AtvpScriptController.java
@@ -1,0 +1,33 @@
+package cn.har01d.alist_tvbox.web;
+
+import cn.har01d.alist_tvbox.service.AtvpScriptService;
+import cn.har01d.alist_tvbox.service.SubscriptionService;
+import org.springframework.http.CacheControl;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@RestController
+public class AtvpScriptController {
+    private final AtvpScriptService atvpScriptService;
+    private final SubscriptionService subscriptionService;
+
+    public AtvpScriptController(AtvpScriptService atvpScriptService, SubscriptionService subscriptionService) {
+        this.atvpScriptService = atvpScriptService;
+        this.subscriptionService = subscriptionService;
+    }
+
+    @GetMapping(value = "/Atvp/{token}/{version}.py", produces = "text/plain;charset=UTF-8")
+    public ResponseEntity<String> atvp(@PathVariable String token, @PathVariable String version) throws IOException {
+        subscriptionService.checkToken(token);
+        return ResponseEntity.ok()
+                .cacheControl(CacheControl.noStore())
+                .contentType(new MediaType("text", "plain", StandardCharsets.UTF_8))
+                .body(atvpScriptService.render());
+    }
+}

--- a/src/main/java/cn/har01d/alist_tvbox/web/PluginController.java
+++ b/src/main/java/cn/har01d/alist_tvbox/web/PluginController.java
@@ -109,6 +109,11 @@ public class PluginController {
         );
     }
 
+    @PostMapping("/compatibility-check/secspider")
+    public PluginCompilerService.CompatibilityCheckResponse checkSecspiderCompatibility(@RequestBody PluginCompilerService.CompatibilityCheckRequest request) {
+        return pluginCompilerService.checkMagnetSpiderCompatibility(request);
+    }
+
     @PutMapping("/{id}")
     public Plugin update(@PathVariable Integer id, @RequestBody Plugin plugin) {
         return pluginService.update(id, plugin);

--- a/src/main/java/cn/har01d/alist_tvbox/web/PluginController.java
+++ b/src/main/java/cn/har01d/alist_tvbox/web/PluginController.java
@@ -1,7 +1,12 @@
 package cn.har01d.alist_tvbox.web;
 
 import cn.har01d.alist_tvbox.entity.Plugin;
+import cn.har01d.alist_tvbox.service.PluginCompilerService;
 import cn.har01d.alist_tvbox.service.PluginService;
+import cn.har01d.alist_tvbox.service.SecspiderKeyService;
+import cn.har01d.alist_tvbox.service.SelfPluginFileService;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +15,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -18,6 +24,9 @@ import java.util.List;
 @RequestMapping("/api/plugins")
 public class PluginController {
     private final PluginService pluginService;
+    private final PluginCompilerService pluginCompilerService;
+    private final SecspiderKeyService secspiderKeyService;
+    private final SelfPluginFileService selfPluginFileService;
 
     private record PluginImportRequest(String url) {
     }
@@ -25,8 +34,14 @@ public class PluginController {
     private record PluginBatchDeleteRequest(List<Integer> ids) {
     }
 
-    public PluginController(PluginService pluginService) {
+    public PluginController(PluginService pluginService,
+                            PluginCompilerService pluginCompilerService,
+                            SecspiderKeyService secspiderKeyService,
+                            SelfPluginFileService selfPluginFileService) {
         this.pluginService = pluginService;
+        this.pluginCompilerService = pluginCompilerService;
+        this.secspiderKeyService = secspiderKeyService;
+        this.selfPluginFileService = selfPluginFileService;
     }
 
     @GetMapping
@@ -44,6 +59,54 @@ public class PluginController {
     @PostMapping("/import")
     public PluginService.ImportResult importPlugins(@RequestBody PluginImportRequest request) {
         return pluginService.importFromSource(request.url());
+    }
+
+    @GetMapping("/secspider/key")
+    public SecspiderKeyService.KeyStatus secspiderKeyStatus() {
+        return secspiderKeyService.ensureKeyMaterial();
+    }
+
+    @PostMapping("/secspider/key/generate")
+    public SecspiderKeyService.KeyStatus generateSecspiderKey() {
+        return secspiderKeyService.generateKeyMaterial(false);
+    }
+
+    @PostMapping("/secspider/key/reset")
+    public SecspiderKeyService.KeyStatus resetSecspiderKey() {
+        return secspiderKeyService.generateKeyMaterial(true);
+    }
+
+    @PostMapping("/compile/secspider")
+    public PluginCompilerService.CompileResponse compileSecspider(@RequestBody PluginCompilerService.CompileRequest request) {
+        PluginCompilerService.CompileRequest compileRequest = withManagedKeyMaterial(request);
+        PluginCompilerService.CompileResponse response = pluginCompilerService.compileSecspider(compileRequest);
+        if (!Boolean.TRUE.equals(compileRequest.autoImport())) {
+            return response;
+        }
+
+        String pluginId = StringUtils.defaultIfBlank(compileRequest.id(), derivePluginId(compileRequest.name()));
+        String contextPath = ServletUriComponentsBuilder.fromCurrentContextPath().build().toUriString();
+        SelfPluginFileService.StoredPlugin storedPlugin = selfPluginFileService.store(
+                pluginId,
+                compileRequest.version(),
+                response.packageText(),
+                contextPath
+        );
+        Plugin plugin = pluginService.upsertCompiledPlugin(
+                storedPlugin.pluginUrl(),
+                storedPlugin.localPath(),
+                pluginId,
+                compileRequest.name(),
+                compileRequest.version(),
+                response.packageText()
+        );
+        return response.withImportedPlugin(
+                plugin.getId(),
+                plugin.getName(),
+                storedPlugin.pluginUrl(),
+                storedPlugin.repositoryUrl(),
+                storedPlugin.localPath()
+        );
     }
 
     @PutMapping("/{id}")
@@ -69,5 +132,54 @@ public class PluginController {
     @PostMapping("/delete-batch")
     public int deleteBatch(@RequestBody PluginBatchDeleteRequest request) {
         return pluginService.deleteBatch(request.ids());
+    }
+
+    private PluginCompilerService.CompileRequest withManagedKeyMaterial(PluginCompilerService.CompileRequest request) {
+        boolean useManagedKey = Boolean.TRUE.equals(request.useManagedKey())
+                || StringUtils.isBlank(request.privateKey())
+                || StringUtils.isBlank(request.masterSecret());
+        String pluginId = StringUtils.defaultIfBlank(request.id(), derivePluginId(request.name()));
+        if (!useManagedKey) {
+            return new PluginCompilerService.CompileRequest(
+                    request.name(),
+                    request.version(),
+                    request.remark(),
+                    pluginId,
+                    request.kid(),
+                    request.source(),
+                    request.privateKey(),
+                    request.publicKey(),
+                    request.masterSecret(),
+                    request.useManagedKey(),
+                    request.autoImport()
+            );
+        }
+
+        SecspiderKeyService.CompilerKeyMaterial keyMaterial = secspiderKeyService.compilerKeyMaterial();
+        return new PluginCompilerService.CompileRequest(
+                request.name(),
+                request.version(),
+                request.remark(),
+                pluginId,
+                StringUtils.defaultIfBlank(request.kid(), "self"),
+                request.source(),
+                keyMaterial.privateKey(),
+                keyMaterial.publicKey(),
+                keyMaterial.masterSecret(),
+                true,
+                request.autoImport()
+        );
+    }
+
+    private String derivePluginId(String name) {
+        String normalized = StringUtils.defaultString(name)
+                .trim()
+                .toLowerCase()
+                .replaceAll("[^a-z0-9_.-]+", "_")
+                .replaceAll("^_+|_+$", "");
+        if (StringUtils.isNotBlank(normalized)) {
+            return normalized.length() > 80 ? normalized.substring(0, 80) : normalized;
+        }
+        return "plugin_" + DigestUtils.sha256Hex(StringUtils.defaultString(name)).substring(0, 12);
     }
 }

--- a/src/main/resources/static/Atvp.py
+++ b/src/main/resources/static/Atvp.py
@@ -180,6 +180,8 @@ class Spider(HostSpider):
         "T0wEER4QHQQdTEtMEEodTw==",
         "HxodEBlLSEoEERFIEQQdHA==",
     ]
+    _self_public_key_chunks = []
+    _self_master_secret_chunks = []
 
     def __init__(self):
         super().__init__()
@@ -191,6 +193,7 @@ class Spider(HostSpider):
         self._detail_result_cache = {}
         self._play_context_cache = {}
         self._filters = []
+        self._secspider_loader = "auto"
 
     def init(self, extend=""):
         self.extend = extend or ""
@@ -199,6 +202,7 @@ class Spider(HostSpider):
         self._backend_api = self._resolve_backend_api(source, payload)
         self._vod_token = self._resolve_vod_token(payload)
         self._localProxyConfig = payload.get("local_proxy_config") if isinstance(payload, dict) else {}
+        self._secspider_loader = self._resolve_secspider_loader(payload)
         package_text = self._load_source(source)
         source_text = package_text if self._is_raw_source(payload) else self._decrypt_secspider_source(package_text)
         spider_cls = self._load_inner_spider_class(source_text)
@@ -300,6 +304,16 @@ class Spider(HostSpider):
             return ""
         token = str(payload.get("token") or "").strip()
         return "" if token == "-" else token
+
+    def _resolve_secspider_loader(self, payload):
+        if not isinstance(payload, dict):
+            return "auto"
+        value = str(
+            payload.get("secspider_loader")
+            or payload.get("secspiderLoader")
+            or "auto"
+        ).strip().lower()
+        return value or "auto"
 
     def _build_backend_endpoint(self, path):
         backend_api = str(self._backend_api or "").rstrip("/")
@@ -420,20 +434,79 @@ class Spider(HostSpider):
             base64.b64decode(self._strip_prefix(headers["sig"], "base64:")),
         )
 
-    def _decrypt_secspider_source(self, package_text):
-        headers, payload_b64 = self._parse_secspider_text(package_text)
-        public_key_text = self._deobfuscate_chunks(
-            self._public_key_chunks,
-            self.PUBLIC_KEY_XOR,
-        )
-        master_secret = self._deobfuscate_chunks(
-            self._master_secret_chunks,
-            self.MASTER_SECRET_XOR,
-        ).encode("utf-8")
+    def _load_external_self_keyring(self):
+        candidates = []
+        env_path = str(os.environ.get("ATV_SECSPIDER_KEYRING") or "").strip()
+        if env_path:
+            candidates.append(env_path)
+        candidates.extend([
+            "/data/secspider/atvp-keyring.json",
+            "/opt/atv/data/secspider/atvp-keyring.json",
+        ])
+        for candidate in candidates:
+            try:
+                if not candidate or not os.path.isfile(candidate):
+                    continue
+                with open(candidate, "r", encoding="utf-8") as fp:
+                    payload = json.load(fp)
+                public_chunks = (
+                    payload.get("publicKeyChunks")
+                    or payload.get("public_key_chunks")
+                    or []
+                )
+                secret_chunks = (
+                    payload.get("masterSecretChunks")
+                    or payload.get("master_secret_chunks")
+                    or []
+                )
+                if isinstance(public_chunks, list) and isinstance(secret_chunks, list) and public_chunks and secret_chunks:
+                    return public_chunks, secret_chunks
+            except Exception as e:
+                self.log(f"Atvp external self keyring load failed: {candidate} {e}")
+        return None
+
+    def _iter_secspider_keyrings(self):
+        external_self_keyring = self._load_external_self_keyring()
+        self_public_chunks = self._self_public_key_chunks
+        self_secret_chunks = self._self_master_secret_chunks
+        if external_self_keyring:
+            self_public_chunks, self_secret_chunks = external_self_keyring
+
+        keyrings = [
+            (
+                "stock",
+                self._public_key_chunks,
+                self._master_secret_chunks,
+                self.PUBLIC_KEY_XOR,
+                self.MASTER_SECRET_XOR,
+            )
+        ]
+        if self_public_chunks and self_secret_chunks:
+            keyrings.append(
+                (
+                    "self",
+                    self_public_chunks,
+                    self_secret_chunks,
+                    self.PUBLIC_KEY_XOR,
+                    self.MASTER_SECRET_XOR,
+                )
+            )
+
+        selected = str(self._secspider_loader or "auto").strip().lower()
+        if selected in ("auto", "dual", "*"):
+            return keyrings
+        return [keyring for keyring in keyrings if keyring[0] == selected] or keyrings
+
+    def _decrypt_secspider_source_with_keyring(self, headers, payload_b64, keyring):
+        loader_name, public_chunks, secret_chunks, public_xor, secret_xor = keyring
+        public_key_text = self._deobfuscate_chunks(public_chunks, public_xor)
+        master_secret = self._deobfuscate_chunks(secret_chunks, secret_xor).encode("utf-8")
         try:
             self._verify_signature(headers, payload_b64, public_key_text)
-        except ImportError:
-            self.log("Atvp: Crypto.Signature.eddsa unavailable, skip secspider signature verification")
+        except ImportError as e:
+            raise RuntimeError(
+                f"Atvp secspider signature verification unavailable for {loader_name}"
+            ) from e
         wrap_key = HKDF(
             master=master_secret,
             key_len=32,
@@ -462,6 +535,24 @@ class Spider(HostSpider):
         if headers["hash"] != f"sha256:{source_hash}":
             raise ValueError("Atvp secspider source hash mismatch")
         return source_bytes.decode("utf-8")
+
+    def _decrypt_secspider_source(self, package_text):
+        headers, payload_b64 = self._parse_secspider_text(package_text)
+        keyrings = self._iter_secspider_keyrings()
+        errors = []
+        for keyring in keyrings:
+            loader_name = keyring[0]
+            try:
+                source = self._decrypt_secspider_source_with_keyring(headers, payload_b64, keyring)
+                if loader_name != "stock":
+                    self.log(f"Atvp secspider loader selected: {loader_name}")
+                return source
+            except Exception as e:
+                errors.append((loader_name, e))
+        if len(errors) == 1:
+            raise errors[0][1]
+        details = "; ".join(f"{name}: {type(error).__name__}: {error}" for name, error in errors)
+        raise ValueError(f"Atvp secspider decrypt failed for all loaders: {details}")
 
     def _sanitize_html_content(self, content):
         if isinstance(content, bytes):

--- a/src/test/java/cn/har01d/alist_tvbox/service/AtvpScriptServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/AtvpScriptServiceTest.java
@@ -1,0 +1,37 @@
+package cn.har01d.alist_tvbox.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AtvpScriptServiceTest {
+    @Test
+    void renderShouldInjectManagedSelfKeyringChunks() throws Exception {
+        SecspiderKeyService secspiderKeyService = mock(SecspiderKeyService.class);
+        when(secspiderKeyService.ensureKeyMaterial()).thenReturn(new SecspiderKeyService.KeyStatus(
+                true,
+                "/data/secspider/self-ed25519-private.pem",
+                "/data/secspider/self-ed25519-public.pem",
+                "/data/secspider/self-master-secret.txt",
+                "/data/secspider/atvp-keyring.json",
+                "public-key",
+                List.of("pub-a", "pub-b"),
+                List.of("secret-a", "secret-b")
+        ));
+
+        AtvpScriptService service = new AtvpScriptService(secspiderKeyService, new ObjectMapper());
+
+        String script = service.render();
+
+        assertThat(script).contains("    _self_public_key_chunks = [\"pub-a\",\"pub-b\"]");
+        assertThat(script).contains("    _self_master_secret_chunks = [\"secret-a\",\"secret-b\"]");
+        assertThat(script).doesNotContain("    _self_public_key_chunks = []");
+        assertThat(script).doesNotContain("    _self_master_secret_chunks = []");
+        assertThat(service.version()).hasSize(12);
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/service/PluginCompilerAtvpInteropTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/PluginCompilerAtvpInteropTest.java
@@ -1,0 +1,185 @@
+package cn.har01d.alist_tvbox.service;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.NamedParameterSpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PluginCompilerAtvpInteropTest {
+    private final PluginCompilerService service = new PluginCompilerService();
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void generatedSelfPackageShouldDecryptWithAtvpSelfKeyring() throws Exception {
+        Assumptions.assumeTrue(pythonHasAtvpDependencies(), "Python Atvp dependencies are not installed");
+
+        KeyPair keyPair = generateKeyPair();
+        String source = """
+                from base.spider import Spider
+
+                class Spider(Spider):
+                    def init(self, extend=""):
+                        self.extend = extend
+                        return "inner-init-ok"
+
+                    def getName(self):
+                        return "Interop"
+
+                    def playerContent(self, flag, id, vipFlags):
+                        return {"parse": 0, "url": "https://example.invalid/video.mp4", "header": {"X-Test": "self"}}
+                """;
+        PluginCompilerService.CompileResponse response = service.compileSecspider(
+                new PluginCompilerService.CompileRequest(
+                        "Interop",
+                        7,
+                        "",
+                        "interop-self",
+                        "interop-kid",
+                        source,
+                        pem("PRIVATE KEY", keyPair.getPrivate().getEncoded()),
+                        pem("PUBLIC KEY", keyPair.getPublic().getEncoded()),
+                        "interop-master-secret"
+                )
+        );
+
+        Path atvp = tempDir.resolve("Atvp.py");
+        String atvpText = Files.readString(Path.of("src/main/resources/static/Atvp.py"), StandardCharsets.UTF_8);
+        atvpText = replacePythonListAssignment(atvpText, "_self_public_key_chunks", pyList(response.publicKeyChunks()));
+        atvpText = replacePythonListAssignment(atvpText, "_self_master_secret_chunks", pyList(response.masterSecretChunks()));
+        Files.writeString(atvp, atvpText, StandardCharsets.UTF_8);
+
+        Path packageFile = tempDir.resolve("package.txt");
+        Files.writeString(packageFile, response.packageText(), StandardCharsets.UTF_8);
+        Path runner = tempDir.resolve("run_atvp_decrypt.py");
+        Files.writeString(runner, runnerScript(atvp, packageFile), StandardCharsets.UTF_8);
+
+        ProcessResult result = runPython(runner);
+        assertThat(result.exitCode()).as(result.stderr()).isZero();
+        assertThat(result.stdout()).contains("DECRYPT_OK");
+        assertThat(result.stdout()).contains("Atvp secspider loader selected: self");
+        assertThat(result.stdout()).contains("RUNTIME_INIT inner-init-ok");
+        assertThat(result.stdout()).contains("RUNTIME_NAME Interop");
+        assertThat(result.stdout()).contains("RUNTIME_PLAYER");
+        assertThat(result.stdout()).contains("https://example.invalid/video.mp4");
+    }
+
+    private boolean pythonHasAtvpDependencies() throws Exception {
+        String script = "import Crypto, requests, lxml\nfrom Crypto.Signature import eddsa\n";
+        ProcessBuilder builder = new ProcessBuilder("python", "-c", script)
+                .directory(Path.of(".").toFile())
+                .redirectErrorStream(true);
+        addPythonPath(builder.environment());
+        Process process = builder.start();
+        return process.waitFor() == 0;
+    }
+
+    private ProcessResult runPython(Path runner) throws Exception {
+        ProcessBuilder builder = new ProcessBuilder("python", runner.toString())
+                .directory(Path.of(".").toFile());
+        addPythonPath(builder.environment());
+        Process process = builder.start();
+        String stdout = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        String stderr = new String(process.getErrorStream().readAllBytes(), StandardCharsets.UTF_8);
+        return new ProcessResult(process.waitFor(), stdout, stderr);
+    }
+
+    private void addPythonPath(Map<String, String> environment) {
+        Path pydeps = Path.of("work", "pydeps").toAbsolutePath();
+        if (!Files.isDirectory(pydeps)) {
+            return;
+        }
+        String existing = environment.getOrDefault("PYTHONPATH", "");
+        environment.put("PYTHONPATH", existing.isBlank() ? pydeps.toString() : pydeps + ";" + existing);
+    }
+
+    private String runnerScript(Path atvp, Path packageFile) {
+        return """
+                import importlib.util
+                import base64
+                import sys
+                import json
+                import types
+
+                base_mod = types.ModuleType("base")
+                spider_mod = types.ModuleType("base.spider")
+                class BaseSpider:
+                    def init(self, extend=""):
+                        self.extend = extend
+                        return None
+                    def log(self, *args):
+                        print(*args)
+                spider_mod.Spider = BaseSpider
+                sys.modules["base"] = base_mod
+                sys.modules["base.spider"] = spider_mod
+
+                spec = importlib.util.spec_from_file_location("atvp_interop", r"%s")
+                mod = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(mod)
+                spider = mod.Spider()
+                package_path = r"%s"
+                plain = spider._decrypt_secspider_source(open(package_path, encoding="utf-8").read())
+                print("DECRYPT_OK")
+                print(plain)
+                payload = {
+                    "source": package_path,
+                    "secspider_loader": "self",
+                    "token": "-",
+                    "local_proxy_config": {},
+                }
+                extend = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+                print("RUNTIME_INIT", spider.init(extend))
+                print("RUNTIME_NAME", spider.getName())
+                print("RUNTIME_PLAYER", json.dumps(spider.playerContent("test", "video-id", []), ensure_ascii=False, sort_keys=True))
+                """.formatted(escapePath(atvp), escapePath(packageFile));
+    }
+
+    private String escapePath(Path path) {
+        return path.toAbsolutePath().toString().replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private String pyList(List<String> values) {
+        StringBuilder builder = new StringBuilder("[");
+        for (int i = 0; i < values.size(); i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            builder.append("\"").append(values.get(i).replace("\\", "\\\\").replace("\"", "\\\"")).append("\"");
+        }
+        return builder.append("]").toString();
+    }
+
+    private String replacePythonListAssignment(String source, String name, String replacementList) {
+        return source.replaceFirst(
+                "(?s)(?m)^    " + name + " = \\[(?:.*?^    \\]|[^\\n]*\\])",
+                "    " + name + " = " + replacementList
+        );
+    }
+
+    private KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("Ed25519");
+        generator.initialize(NamedParameterSpec.ED25519);
+        return generator.generateKeyPair();
+    }
+
+    private String pem(String type, byte[] bytes) {
+        return "-----BEGIN " + type + "-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(bytes)
+                + "\n-----END " + type + "-----";
+    }
+
+    private record ProcessResult(int exitCode, String stdout, String stderr) {
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/service/PluginCompilerCompatibilityTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/PluginCompilerCompatibilityTest.java
@@ -41,6 +41,9 @@ class PluginCompilerCompatibilityTest {
         assertThat(response.failCount()).isZero();
         assertThat(response.passCount()).isEqualTo(response.items().size());
         assertThat(response.items()).allMatch(item -> "PASS".equals(item.status()));
+        assertThat(response.aiRepairExportText()).contains("\"exportType\" : \"AI修复导出\"");
+        assertThat(response.aiRepairExportText()).contains("\"description\" : \"把错误项需要修改的地方用 AI 更容易理解的方式导出成文本");
+        assertThat(response.aiRepairExportText()).contains("\"source\"");
     }
 
     @Test
@@ -70,5 +73,7 @@ class PluginCompilerCompatibilityTest {
         assertThat(response.items()).anyMatch(item -> item.code().equals("player_content") && item.status().equals("FAIL"));
         assertThat(response.items()).anyMatch(item -> item.code().equals("vod_pic") && item.status().equals("FAIL"));
         assertThat(response.items()).anyMatch(item -> item.code().equals("magnet_flow") && item.status().equals("FAIL"));
+        assertThat(response.aiRepairExportText()).contains("\"repairSuggestions\"");
+        assertThat(response.aiRepairExportText()).contains("AI修复导出");
     }
 }

--- a/src/test/java/cn/har01d/alist_tvbox/service/PluginCompilerCompatibilityTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/PluginCompilerCompatibilityTest.java
@@ -1,0 +1,74 @@
+package cn.har01d.alist_tvbox.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PluginCompilerCompatibilityTest {
+    private final PluginCompilerService service = new PluginCompilerService();
+
+    @Test
+    void checkMagnetSpiderCompatibilityShouldPassForCompliantSource() {
+        String source = """
+                from base.spider import Spider
+
+                class Spider(Spider):
+                    def detailContent(self, aid):
+                        return {
+                            "list": [{
+                                "vod_name": aid,
+                                "vod_pic": "https://example.invalid/poster.jpg",
+                                "vod_play_from": "磁力",
+                                "vod_play_url": "正片$magnet:?xt=urn:btih:0123456789ABCDEF0123456789ABCDEF"
+                            }]
+                        }
+
+                    def playerContent(self, flag, id, vipFlags):
+                        return {"parse": 0, "url": id}
+                """;
+
+        PluginCompilerService.CompatibilityCheckResponse response = service.checkMagnetSpiderCompatibility(
+                new PluginCompilerService.CompatibilityCheckRequest(
+                        "JavBus",
+                        3,
+                        "",
+                        "javbus_self",
+                        source
+                )
+        );
+
+        assertThat(response.passed()).isTrue();
+        assertThat(response.failCount()).isZero();
+        assertThat(response.passCount()).isEqualTo(response.items().size());
+        assertThat(response.items()).allMatch(item -> "PASS".equals(item.status()));
+    }
+
+    @Test
+    void checkMagnetSpiderCompatibilityShouldReportMissingRules() {
+        String source = """
+                //@name:Oops
+                from base.spider import Spider
+
+                class Spider(Spider):
+                    pass
+                """;
+
+        PluginCompilerService.CompatibilityCheckResponse response = service.checkMagnetSpiderCompatibility(
+                new PluginCompilerService.CompatibilityCheckRequest(
+                        "Oops",
+                        1,
+                        "",
+                        "",
+                        source
+                )
+        );
+
+        assertThat(response.passed()).isFalse();
+        assertThat(response.failCount()).isGreaterThan(0);
+        assertThat(response.items()).anyMatch(item -> item.code().equals("outer_headers") && item.status().equals("FAIL"));
+        assertThat(response.items()).anyMatch(item -> item.code().equals("detail_content") && item.status().equals("FAIL"));
+        assertThat(response.items()).anyMatch(item -> item.code().equals("player_content") && item.status().equals("FAIL"));
+        assertThat(response.items()).anyMatch(item -> item.code().equals("vod_pic") && item.status().equals("FAIL"));
+        assertThat(response.items()).anyMatch(item -> item.code().equals("magnet_flow") && item.status().equals("FAIL"));
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/service/PluginCompilerServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/PluginCompilerServiceTest.java
@@ -1,0 +1,299 @@
+package cn.har01d.alist_tvbox.service;
+
+import cn.har01d.alist_tvbox.exception.BadRequestException;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.security.spec.NamedParameterSpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PluginCompilerServiceTest {
+    private static final int PUBLIC_KEY_XOR = 23;
+    private static final int MASTER_SECRET_XOR = 41;
+
+    private final PluginCompilerService service = new PluginCompilerService();
+
+    @Test
+    void compileSecspiderShouldSignEncryptAndReturnKeyringChunks() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+
+        String privateKey = pem("PRIVATE KEY", keyPair.getPrivate().getEncoded());
+        String publicKey = pem("PUBLIC KEY", keyPair.getPublic().getEncoded());
+        String source = "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n";
+        String masterSecret = "self-master-secret-for-test";
+
+        PluginCompilerService.CompileResponse response = service.compileSecspider(
+                new PluginCompilerService.CompileRequest(
+                        "SelfPlugin",
+                        3,
+                        "",
+                        "self-plugin-id",
+                        "self-kid",
+                        source,
+                        privateKey,
+                        publicKey,
+                        masterSecret
+                )
+        );
+
+        assertThat(response.packageText()).contains("//@format:secspider/1");
+        assertThat(response.packageText()).contains("//@sign:ed25519");
+        assertThat(response.packageText()).contains("//@kid:self-kid");
+        assertThat(response.packageText()).doesNotContain(privateKey);
+        assertThat(response.plainSha256()).isEqualTo(sha256Hex(source.getBytes(StandardCharsets.UTF_8)));
+        assertThat(response.publicKeyChunks()).isNotEmpty();
+        assertThat(response.masterSecretChunks()).isNotEmpty();
+
+        Map<String, String> headers = parseHeaders(response.packageText());
+        String payloadB64 = parsePayload(response.packageText());
+        verifySignature(keyPair, headers, payloadB64);
+
+        byte[] wrapKey = hkdf(
+                masterSecret.getBytes(StandardCharsets.UTF_8),
+                headers.get("kid").getBytes(StandardCharsets.UTF_8),
+                "secspider:SelfPlugin:3:wrap-key".getBytes(StandardCharsets.UTF_8),
+                32
+        );
+        byte[] wrapNonce = hkdf(
+                masterSecret.getBytes(StandardCharsets.UTF_8),
+                headers.get("kid").getBytes(StandardCharsets.UTF_8),
+                "secspider:SelfPlugin:3:wrap-nonce".getBytes(StandardCharsets.UTF_8),
+                12
+        );
+        byte[] contentKey = aesGcmDecrypt(wrapKey, wrapNonce, b64(stripPrefix(headers.get("ek"), "base64:")));
+        byte[] plaintext = aesGcmDecrypt(
+                contentKey,
+                b64(stripPrefix(headers.get("nonce"), "base64:")),
+                b64(payloadB64)
+        );
+
+        assertThat(new String(plaintext, StandardCharsets.UTF_8)).isEqualTo(source);
+        assertThat(deobfuscate(response.publicKeyChunks(), PUBLIC_KEY_XOR)).contains("-----BEGIN PUBLIC KEY-----");
+        assertThat(deobfuscate(response.masterSecretChunks(), MASTER_SECRET_XOR)).isEqualTo(masterSecret);
+    }
+
+    @Test
+    void compileSecspiderShouldNormalizeBase64DerPublicKeyChunks() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        String publicKeyBase64 = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
+
+        PluginCompilerService.CompileResponse response = service.compileSecspider(
+                new PluginCompilerService.CompileRequest(
+                        "SelfPlugin",
+                        1,
+                        "",
+                        "self-plugin-id",
+                        "self-kid",
+                        "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
+                        pem("PRIVATE KEY", keyPair.getPrivate().getEncoded()),
+                        publicKeyBase64,
+                        "self-master-secret-for-test"
+                )
+        );
+
+        String restoredPublicKey = deobfuscate(response.publicKeyChunks(), PUBLIC_KEY_XOR);
+        assertThat(restoredPublicKey).startsWith("-----BEGIN PUBLIC KEY-----");
+        assertThat(restoredPublicKey).endsWith("-----END PUBLIC KEY-----");
+    }
+
+    @Test
+    void compileSecspiderShouldRejectMismatchedPublicKey() throws Exception {
+        KeyPair signingKey = generateKeyPair();
+        KeyPair wrongKey = generateKeyPair();
+
+        assertThatThrownBy(() -> service.compileSecspider(
+                new PluginCompilerService.CompileRequest(
+                        "SelfPlugin",
+                        1,
+                        "",
+                        "self-plugin-id",
+                        "self-kid",
+                        "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
+                        pem("PRIVATE KEY", signingKey.getPrivate().getEncoded()),
+                        pem("PUBLIC KEY", wrongKey.getPublic().getEncoded()),
+                        "self-master-secret-for-test"
+                )
+        ))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("公钥与私钥不匹配");
+    }
+
+    @Test
+    void compileSecspiderShouldRejectHeaderInjection() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+
+        assertThatThrownBy(() -> service.compileSecspider(
+                new PluginCompilerService.CompileRequest(
+                        "SelfPlugin\n//@format:plain",
+                        1,
+                        "",
+                        "self-plugin-id",
+                        "self-kid",
+                        "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
+                        pem("PRIVATE KEY", keyPair.getPrivate().getEncoded()),
+                        pem("PUBLIC KEY", keyPair.getPublic().getEncoded()),
+                        "self-master-secret-for-test"
+                )
+        ))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("不能包含换行");
+    }
+
+    @Test
+    void compileSecspiderShouldAcceptRawSeedPrivateKey() {
+        byte[] seed = new byte[32];
+        new SecureRandom().nextBytes(seed);
+
+        PluginCompilerService.CompileResponse response = service.compileSecspider(
+                new PluginCompilerService.CompileRequest(
+                        "SeedPlugin",
+                        1,
+                        "",
+                        "seed-plugin-id",
+                        "seed-kid",
+                        "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
+                        HexFormat.of().formatHex(seed),
+                        "",
+                        "self-master-secret-for-test"
+                )
+        );
+
+        assertThat(response.packageText()).contains("//@sig:base64:");
+        assertThat(response.publicKeyChunks()).isEmpty();
+    }
+
+    private KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("Ed25519");
+        generator.initialize(NamedParameterSpec.ED25519);
+        return generator.generateKeyPair();
+    }
+
+    private String pem(String type, byte[] bytes) {
+        return "-----BEGIN " + type + "-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(bytes)
+                + "\n-----END " + type + "-----";
+    }
+
+    private Map<String, String> parseHeaders(String text) {
+        Map<String, String> headers = new HashMap<>();
+        for (String line : text.split("\\R")) {
+            if (line.startsWith("//@")) {
+                String body = line.substring(3);
+                int index = body.indexOf(':');
+                headers.put(body.substring(0, index), body.substring(index + 1));
+            }
+        }
+        return headers;
+    }
+
+    private String parsePayload(String text) {
+        for (String line : text.split("\\R")) {
+            if (line.startsWith("payload.base64:")) {
+                return stripPrefix(line, "payload.base64:");
+            }
+        }
+        throw new IllegalArgumentException("missing payload");
+    }
+
+    private void verifySignature(KeyPair keyPair, Map<String, String> headers, String payloadB64) throws Exception {
+        Signature signature = Signature.getInstance("Ed25519");
+        signature.initVerify(keyPair.getPublic());
+        signature.update(buildSigningBytes(headers, payloadB64));
+        assertThat(signature.verify(b64(stripPrefix(headers.get("sig"), "base64:")))).isTrue();
+    }
+
+    private byte[] buildSigningBytes(Map<String, String> headers, String payloadB64) {
+        String text = String.join("\n",
+                "//@name:" + headers.get("name"),
+                "//@version:" + headers.get("version"),
+                "//@remark:" + headers.get("remark"),
+                "//@id:" + headers.get("id"),
+                "//@format:" + headers.get("format"),
+                "//@alg:" + headers.get("alg"),
+                "//@wrap:" + headers.get("wrap"),
+                "//@sign:" + headers.get("sign"),
+                "//@kid:" + headers.get("kid"),
+                "//@nonce:" + headers.get("nonce"),
+                "//@ek:" + headers.get("ek"),
+                "//@hash:" + headers.get("hash"),
+                "payload.base64:" + payloadB64
+        );
+        return text.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private byte[] aesGcmDecrypt(byte[] key, byte[] nonce, byte[] blob) throws Exception {
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new GCMParameterSpec(128, nonce));
+        return cipher.doFinal(blob);
+    }
+
+    private byte[] hkdf(byte[] master, byte[] salt, byte[] info, int length) throws Exception {
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(salt, "HmacSHA256"));
+        byte[] prk = mac.doFinal(master);
+        byte[] result = new byte[length];
+        byte[] previous = new byte[0];
+        int offset = 0;
+        int counter = 1;
+        while (offset < length) {
+            mac.init(new SecretKeySpec(prk, "HmacSHA256"));
+            mac.update(previous);
+            mac.update(info);
+            mac.update((byte) counter);
+            previous = mac.doFinal();
+            int copy = Math.min(previous.length, length - offset);
+            System.arraycopy(previous, 0, result, offset, copy);
+            offset += copy;
+            counter++;
+        }
+        return result;
+    }
+
+    private String sha256Hex(byte[] bytes) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+    }
+
+    private byte[] b64(String text) {
+        return Base64.getDecoder().decode(text);
+    }
+
+    private String stripPrefix(String text, String prefix) {
+        return text != null && text.startsWith(prefix) ? text.substring(prefix.length()) : text;
+    }
+
+    private String deobfuscate(List<String> chunks, int xorKey) {
+        List<byte[]> decoded = new ArrayList<>();
+        for (int index = chunks.size() - 1; index >= 0; index--) {
+            byte[] chunk = Base64.getDecoder().decode(chunks.get(index));
+            for (int i = 0; i < chunk.length; i++) {
+                chunk[i] = (byte) (chunk[i] ^ xorKey);
+            }
+            decoded.add(chunk);
+        }
+        int size = decoded.stream().mapToInt(item -> item.length).sum();
+        byte[] raw = new byte[size];
+        int offset = 0;
+        for (byte[] chunk : decoded) {
+            System.arraycopy(chunk, 0, raw, offset, chunk.length);
+            offset += chunk.length;
+        }
+        return new String(raw, StandardCharsets.UTF_8);
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/service/SecspiderKeyServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/SecspiderKeyServiceTest.java
@@ -1,0 +1,53 @@
+package cn.har01d.alist_tvbox.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SecspiderKeyServiceTest {
+    @TempDir
+    private Path dataDir;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("atv.data.dir");
+    }
+
+    @Test
+    void ensureAndResetShouldPersistContainerKeyring() throws Exception {
+        System.setProperty("atv.data.dir", dataDir.toString());
+        SecspiderKeyService service = new SecspiderKeyService(objectMapper);
+
+        SecspiderKeyService.KeyStatus first = service.ensureKeyMaterial();
+        SecspiderKeyService.CompilerKeyMaterial firstMaterial = service.compilerKeyMaterial();
+
+        assertThat(first.generated()).isTrue();
+        assertThat(first.publicKey()).startsWith("-----BEGIN PUBLIC KEY-----");
+        assertThat(first.publicKeyChunks()).isNotEmpty();
+        assertThat(first.masterSecretChunks()).isNotEmpty();
+        assertThat(firstMaterial.privateKey()).startsWith("-----BEGIN PRIVATE KEY-----");
+        assertThat(firstMaterial.masterSecret()).startsWith("self-master-");
+        assertThat(Files.isRegularFile(Path.of(first.privateKeyPath()))).isTrue();
+        assertThat(Files.isRegularFile(Path.of(first.keyringPath()))).isTrue();
+
+        JsonNode keyring = objectMapper.readTree(Files.readString(Path.of(first.keyringPath()), StandardCharsets.UTF_8));
+        assertThat(keyring.path("format").asText()).isEqualTo("atvp-secspider-keyring/1");
+        assertThat(keyring.path("publicKeyChunks").isArray()).isTrue();
+        assertThat(keyring.path("masterSecretChunks").isArray()).isTrue();
+
+        SecspiderKeyService.KeyStatus second = service.generateKeyMaterial(true);
+        SecspiderKeyService.CompilerKeyMaterial secondMaterial = service.compilerKeyMaterial();
+        assertThat(second.publicKey()).isNotEqualTo(first.publicKey());
+        assertThat(secondMaterial.masterSecret()).isNotEqualTo(firstMaterial.masterSecret());
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/service/SelfPluginFileServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/SelfPluginFileServiceTest.java
@@ -1,0 +1,52 @@
+package cn.har01d.alist_tvbox.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SelfPluginFileServiceTest {
+    @TempDir
+    private Path webDir;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("atv.web.dir");
+    }
+
+    @Test
+    void storeShouldWritePackageAndUpsertRepositoryIndex() throws Exception {
+        System.setProperty("atv.web.dir", webDir.toString());
+        SelfPluginFileService service = new SelfPluginFileService(objectMapper);
+
+        SelfPluginFileService.StoredPlugin stored = service.store(
+                "javbus_self",
+                3,
+                "//@name:JavBus\npayload.base64:test\n",
+                "http://localhost:4567"
+        );
+        service.store("javbus_self", 4, "updated", "http://localhost:4567");
+
+        Path packagePath = webDir.resolve("static/self-plugins/py/javbus_self.txt");
+        Path indexPath = webDir.resolve("static/self-plugins/spiders_v2.json");
+        assertThat(Files.readString(packagePath, StandardCharsets.UTF_8)).isEqualTo("updated");
+        assertThat(stored.pluginUrl()).isEqualTo("http://localhost:4567/static/self-plugins/py/javbus_self.txt");
+        assertThat(stored.repositoryUrl()).isEqualTo("http://localhost:4567/static/self-plugins/spiders_v2.json");
+
+        JsonNode index = objectMapper.readTree(Files.readString(indexPath, StandardCharsets.UTF_8));
+        assertThat(index).hasSize(1);
+        assertThat(index.get(0).path("id").asText()).isEqualTo("javbus_self");
+        assertThat(index.get(0).path("file").asText()).isEqualTo("py/javbus_self.txt");
+        assertThat(index.get(0).path("version").asInt()).isEqualTo(4);
+        assertThat(index.get(0).path("valid").asBoolean()).isTrue();
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerCompatibilityCheckTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerCompatibilityCheckTest.java
@@ -1,0 +1,68 @@
+package cn.har01d.alist_tvbox.web;
+
+import cn.har01d.alist_tvbox.config.RestErrorHandler;
+import cn.har01d.alist_tvbox.service.PluginCompilerService;
+import cn.har01d.alist_tvbox.service.PluginService;
+import cn.har01d.alist_tvbox.service.SecspiderKeyService;
+import cn.har01d.alist_tvbox.service.SelfPluginFileService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class PluginControllerCompatibilityCheckTest {
+    @Mock
+    private PluginService pluginService;
+    @Mock
+    private SecspiderKeyService secspiderKeyService;
+    @Mock
+    private SelfPluginFileService selfPluginFileService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        PluginController controller = new PluginController(
+                pluginService,
+                new PluginCompilerService(),
+                secspiderKeyService,
+                selfPluginFileService
+        );
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new RestErrorHandler())
+                .build();
+    }
+
+    @Test
+    void checkSecspiderCompatibilityShouldReturnReport() throws Exception {
+        mockMvc.perform(post("/api/plugins/compatibility-check/secspider")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "name", "GateDemo",
+                                "version", 1,
+                                "remark", "",
+                                "source", "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.gateName").value("磁力爬虫门禁"))
+                .andExpect(jsonPath("$.passed").value(false))
+                .andExpect(jsonPath("$.summary").value(containsString("不合规")))
+                .andExpect(jsonPath("$.items").isArray())
+                .andExpect(jsonPath("$.items[0].status").value(not("")));
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerCompatibilityCheckTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerCompatibilityCheckTest.java
@@ -63,6 +63,7 @@ class PluginControllerCompatibilityCheckTest {
                 .andExpect(jsonPath("$.passed").value(false))
                 .andExpect(jsonPath("$.summary").value(containsString("不合规")))
                 .andExpect(jsonPath("$.items").isArray())
-                .andExpect(jsonPath("$.items[0].status").value(not("")));
+                .andExpect(jsonPath("$.items[0].status").value(not("")))
+                .andExpect(jsonPath("$.aiRepairExportText").value(containsString("AI修复导出")));
     }
 }

--- a/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerCompileTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerCompileTest.java
@@ -1,0 +1,145 @@
+package cn.har01d.alist_tvbox.web;
+
+import cn.har01d.alist_tvbox.config.RestErrorHandler;
+import cn.har01d.alist_tvbox.entity.Plugin;
+import cn.har01d.alist_tvbox.service.PluginCompilerService;
+import cn.har01d.alist_tvbox.service.PluginService;
+import cn.har01d.alist_tvbox.service.SecspiderKeyService;
+import cn.har01d.alist_tvbox.service.SelfPluginFileService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.NamedParameterSpec;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class PluginControllerCompileTest {
+    @Mock
+    private PluginService pluginService;
+    @Mock
+    private SecspiderKeyService secspiderKeyService;
+    @Mock
+    private SelfPluginFileService selfPluginFileService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        PluginController controller = new PluginController(
+                pluginService,
+                new PluginCompilerService(),
+                secspiderKeyService,
+                selfPluginFileService
+        );
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new RestErrorHandler())
+                .build();
+    }
+
+    @Test
+    void compileSecspiderShouldReturnPackageWithoutPrivateKey() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        String privateKey = pem("PRIVATE KEY", keyPair.getPrivate().getEncoded());
+        String publicKey = pem("PUBLIC KEY", keyPair.getPublic().getEncoded());
+
+        mockMvc.perform(post("/api/plugins/compile/secspider")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "name", "HttpInterop",
+                                "version", 1,
+                                "remark", "",
+                                "id", "http-interop",
+                                "kid", "http-kid",
+                                "source", "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
+                                "privateKey", privateKey,
+                                "publicKey", publicKey,
+                                "masterSecret", "http-master-secret"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.format").value("secspider/1"))
+                .andExpect(jsonPath("$.packageText").value(containsString("//@format:secspider/1")))
+                .andExpect(jsonPath("$.packageText").value(not(containsString(privateKey))))
+                .andExpect(jsonPath("$.publicKeyChunks").isArray())
+                .andExpect(jsonPath("$.masterSecretChunks").isArray());
+    }
+
+    @Test
+    void compileSecspiderShouldUseManagedKeyAndAutoImport() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        String privateKey = pem("PRIVATE KEY", keyPair.getPrivate().getEncoded());
+        String publicKey = pem("PUBLIC KEY", keyPair.getPublic().getEncoded());
+        when(secspiderKeyService.compilerKeyMaterial())
+                .thenReturn(new SecspiderKeyService.CompilerKeyMaterial(privateKey, publicKey, "managed-master-secret"));
+        when(selfPluginFileService.store(eq("managed-demo"), eq(2), anyString(), anyString()))
+                .thenReturn(new SelfPluginFileService.StoredPlugin(
+                        "/static/self-plugins/py/managed-demo.txt",
+                        "/static/self-plugins/spiders_v2.json",
+                        "http://localhost/static/self-plugins/py/managed-demo.txt",
+                        "http://localhost/static/self-plugins/spiders_v2.json",
+                        "/www/static/self-plugins/py/managed-demo.txt"
+                ));
+        Plugin plugin = new Plugin();
+        plugin.setId(77);
+        plugin.setName("ManagedDemo");
+        when(pluginService.upsertCompiledPlugin(
+                eq("http://localhost/static/self-plugins/py/managed-demo.txt"),
+                eq("/www/static/self-plugins/py/managed-demo.txt"),
+                eq("managed-demo"),
+                eq("ManagedDemo"),
+                eq(2),
+                anyString()
+        )).thenReturn(plugin);
+
+        mockMvc.perform(post("/api/plugins/compile/secspider")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "name", "ManagedDemo",
+                                "version", 2,
+                                "remark", "",
+                                "id", "managed-demo",
+                                "kid", "self",
+                                "source", "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
+                                "useManagedKey", true,
+                                "autoImport", true
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.format").value("secspider/1"))
+                .andExpect(jsonPath("$.packageText").value(not(containsString(privateKey))))
+                .andExpect(jsonPath("$.importedPluginId").value(77))
+                .andExpect(jsonPath("$.pluginUrl").value("http://localhost/static/self-plugins/py/managed-demo.txt"))
+                .andExpect(jsonPath("$.repositoryUrl").value("http://localhost/static/self-plugins/spiders_v2.json"));
+    }
+
+    private KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("Ed25519");
+        generator.initialize(NamedParameterSpec.ED25519);
+        return generator.generateKeyPair();
+    }
+
+    private String pem(String type, byte[] bytes) {
+        return "-----BEGIN " + type + "-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(bytes)
+                + "\n-----END " + type + "-----";
+    }
+}

--- a/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerCompileTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerCompileTest.java
@@ -85,27 +85,27 @@ class PluginControllerCompileTest {
     }
 
     @Test
-    void compileSecspiderShouldUseManagedKeyAndAutoImport() throws Exception {
+    void compileSecspiderShouldUseManagedKeyAndAutoImportWithoutManualFields() throws Exception {
         KeyPair keyPair = generateKeyPair();
         String privateKey = pem("PRIVATE KEY", keyPair.getPrivate().getEncoded());
         String publicKey = pem("PUBLIC KEY", keyPair.getPublic().getEncoded());
         when(secspiderKeyService.compilerKeyMaterial())
                 .thenReturn(new SecspiderKeyService.CompilerKeyMaterial(privateKey, publicKey, "managed-master-secret"));
-        when(selfPluginFileService.store(eq("managed-demo"), eq(2), anyString(), anyString()))
+        when(selfPluginFileService.store(eq("manageddemo"), eq(2), anyString(), anyString()))
                 .thenReturn(new SelfPluginFileService.StoredPlugin(
-                        "/static/self-plugins/py/managed-demo.txt",
+                        "/static/self-plugins/py/manageddemo.txt",
                         "/static/self-plugins/spiders_v2.json",
-                        "http://localhost/static/self-plugins/py/managed-demo.txt",
+                        "http://localhost/static/self-plugins/py/manageddemo.txt",
                         "http://localhost/static/self-plugins/spiders_v2.json",
-                        "/www/static/self-plugins/py/managed-demo.txt"
+                        "/www/static/self-plugins/py/manageddemo.txt"
                 ));
         Plugin plugin = new Plugin();
         plugin.setId(77);
         plugin.setName("ManagedDemo");
         when(pluginService.upsertCompiledPlugin(
-                eq("http://localhost/static/self-plugins/py/managed-demo.txt"),
-                eq("/www/static/self-plugins/py/managed-demo.txt"),
-                eq("managed-demo"),
+                eq("http://localhost/static/self-plugins/py/manageddemo.txt"),
+                eq("/www/static/self-plugins/py/manageddemo.txt"),
+                eq("manageddemo"),
                 eq("ManagedDemo"),
                 eq(2),
                 anyString()
@@ -117,17 +117,16 @@ class PluginControllerCompileTest {
                                 "name", "ManagedDemo",
                                 "version", 2,
                                 "remark", "",
-                                "id", "managed-demo",
-                                "kid", "self",
                                 "source", "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
-                                "useManagedKey", true,
                                 "autoImport", true
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.format").value("secspider/1"))
+                .andExpect(jsonPath("$.kid").value("self"))
                 .andExpect(jsonPath("$.packageText").value(not(containsString(privateKey))))
                 .andExpect(jsonPath("$.importedPluginId").value(77))
-                .andExpect(jsonPath("$.pluginUrl").value("http://localhost/static/self-plugins/py/managed-demo.txt"))
+                .andExpect(jsonPath("$.importedPluginName").value("ManagedDemo"))
+                .andExpect(jsonPath("$.pluginUrl").value("http://localhost/static/self-plugins/py/manageddemo.txt"))
                 .andExpect(jsonPath("$.repositoryUrl").value("http://localhost/static/self-plugins/spiders_v2.json"));
     }
 

--- a/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerSecurityTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerSecurityTest.java
@@ -81,6 +81,14 @@ class PluginControllerSecurityTest {
     }
 
     @Test
+    void compatibilityCheckShouldRequireAuthentication() throws Exception {
+        mockMvc.perform(post("/api/plugins/compatibility-check/secspider")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void compileSecspiderShouldWorkThroughApiKeySecurityChain() throws Exception {
         KeyPair keyPair = generateKeyPair();
         String privateKey = pem("PRIVATE KEY", keyPair.getPrivate().getEncoded());

--- a/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerSecurityTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerSecurityTest.java
@@ -56,6 +56,9 @@ class PluginControllerSecurityTest {
     private TokenFilter tokenFilter;
 
     @Autowired
+    private SecspiderKeyService secspiderKeyService;
+
+    @Autowired
     private WebApplicationContext webApplicationContext;
 
     @Autowired
@@ -82,6 +85,8 @@ class PluginControllerSecurityTest {
         KeyPair keyPair = generateKeyPair();
         String privateKey = pem("PRIVATE KEY", keyPair.getPrivate().getEncoded());
         String publicKey = pem("PUBLIC KEY", keyPair.getPublic().getEncoded());
+        when(secspiderKeyService.compilerKeyMaterial())
+                .thenReturn(new SecspiderKeyService.CompilerKeyMaterial(privateKey, publicKey, "secured-http-master-secret"));
 
         mockMvc.perform(post("/api/plugins/compile/secspider")
                         .header("X-API-KEY", API_KEY)
@@ -90,15 +95,11 @@ class PluginControllerSecurityTest {
                                 "name", "SecuredHttpInterop",
                                 "version", 1,
                                 "remark", "",
-                                "id", "secured-http-interop",
-                                "kid", "secured-http-kid",
-                                "source", "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
-                                "privateKey", privateKey,
-                                "publicKey", publicKey,
-                                "masterSecret", "secured-http-master-secret"
+                                "source", "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n"
                         ))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.format").value("secspider/1"))
+                .andExpect(jsonPath("$.kid").value("self"))
                 .andExpect(jsonPath("$.packageText").value(containsString("//@format:secspider/1")))
                 .andExpect(jsonPath("$.packageText").value(not(containsString(privateKey))))
                 .andExpect(jsonPath("$.publicKeyChunks").isArray())

--- a/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerSecurityTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/web/PluginControllerSecurityTest.java
@@ -1,0 +1,186 @@
+package cn.har01d.alist_tvbox.web;
+
+import cn.har01d.alist_tvbox.auth.TokenFilter;
+import cn.har01d.alist_tvbox.auth.TokenService;
+import cn.har01d.alist_tvbox.config.RestErrorHandler;
+import cn.har01d.alist_tvbox.config.WebSecurityConfiguration;
+import cn.har01d.alist_tvbox.entity.SettingRepository;
+import cn.har01d.alist_tvbox.service.PluginCompilerService;
+import cn.har01d.alist_tvbox.service.PluginService;
+import cn.har01d.alist_tvbox.service.SecspiderKeyService;
+import cn.har01d.alist_tvbox.service.SelfPluginFileService;
+import cn.har01d.alist_tvbox.service.SubscriptionService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.spec.NamedParameterSpec;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringJUnitWebConfig
+@ContextConfiguration(classes = PluginControllerSecurityTest.TestConfig.class)
+class PluginControllerSecurityTest {
+    private static final String API_KEY = "compile-api-key";
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TokenFilter tokenFilter;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private FilterChainProxy springSecurityFilterChain;
+
+    @BeforeEach
+    void setUp() {
+        tokenFilter.setApiKey(API_KEY);
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .addFilters(springSecurityFilterChain)
+                .build();
+    }
+
+    @Test
+    void compileSecspiderShouldRequireAuthentication() throws Exception {
+        mockMvc.perform(post("/api/plugins/compile/secspider")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void compileSecspiderShouldWorkThroughApiKeySecurityChain() throws Exception {
+        KeyPair keyPair = generateKeyPair();
+        String privateKey = pem("PRIVATE KEY", keyPair.getPrivate().getEncoded());
+        String publicKey = pem("PUBLIC KEY", keyPair.getPublic().getEncoded());
+
+        mockMvc.perform(post("/api/plugins/compile/secspider")
+                        .header("X-API-KEY", API_KEY)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(Map.of(
+                                "name", "SecuredHttpInterop",
+                                "version", 1,
+                                "remark", "",
+                                "id", "secured-http-interop",
+                                "kid", "secured-http-kid",
+                                "source", "from base.spider import Spider\n\nclass Spider(Spider):\n    pass\n",
+                                "privateKey", privateKey,
+                                "publicKey", publicKey,
+                                "masterSecret", "secured-http-master-secret"
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.format").value("secspider/1"))
+                .andExpect(jsonPath("$.packageText").value(containsString("//@format:secspider/1")))
+                .andExpect(jsonPath("$.packageText").value(not(containsString(privateKey))))
+                .andExpect(jsonPath("$.publicKeyChunks").isArray())
+                .andExpect(jsonPath("$.masterSecretChunks").isArray());
+    }
+
+    private KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("Ed25519");
+        generator.initialize(NamedParameterSpec.ED25519);
+        return generator.generateKeyPair();
+    }
+
+    private String pem(String type, byte[] bytes) {
+        return "-----BEGIN " + type + "-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8)).encodeToString(bytes)
+                + "\n-----END " + type + "-----";
+    }
+
+    @Configuration
+    @EnableWebMvc
+    @Import(WebSecurityConfiguration.class)
+    static class TestConfig {
+        @Bean
+        PluginController pluginController(PluginService pluginService,
+                                          PluginCompilerService pluginCompilerService,
+                                          SecspiderKeyService secspiderKeyService,
+                                          SelfPluginFileService selfPluginFileService) {
+            return new PluginController(pluginService, pluginCompilerService, secspiderKeyService, selfPluginFileService);
+        }
+
+        @Bean
+        PluginCompilerService pluginCompilerService() {
+            return new PluginCompilerService();
+        }
+
+        @Bean
+        PluginService pluginService() {
+            return mock(PluginService.class);
+        }
+
+        @Bean
+        SecspiderKeyService secspiderKeyService() {
+            return mock(SecspiderKeyService.class);
+        }
+
+        @Bean
+        SelfPluginFileService selfPluginFileService() {
+            return mock(SelfPluginFileService.class);
+        }
+
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+
+        @Bean
+        RestErrorHandler restErrorHandler() {
+            return new RestErrorHandler();
+        }
+
+        @Bean
+        TokenFilter tokenFilter(TokenService tokenService, SettingRepository settingRepository) {
+            return new TokenFilter(tokenService, settingRepository);
+        }
+
+        @Bean
+        TokenService tokenService() {
+            return mock(TokenService.class);
+        }
+
+        @Bean
+        SubscriptionService subscriptionService() {
+            return mock(SubscriptionService.class);
+        }
+
+        @Bean
+        SettingRepository settingRepository() {
+            SettingRepository repository = mock(SettingRepository.class);
+            when(repository.findById("api_key")).thenReturn(Optional.empty());
+            when(repository.findById("basic_auth_username")).thenReturn(Optional.empty());
+            when(repository.findById("basic_auth_password")).thenReturn(Optional.empty());
+            return repository;
+        }
+    }
+}

--- a/web-ui/src/views/SubscriptionsView.test.mjs
+++ b/web-ui/src/views/SubscriptionsView.test.mjs
@@ -36,9 +36,14 @@ test('accepts encrypted txt and raw Python plugin addresses', () => {
 
 test('exposes compatibility gate entry in the plugin compiler dialog', () => {
   assert.equal(viewSource.includes('兼容性校验'), true)
+  assert.equal(viewSource.includes('pluginCompatibilityVisible'), true)
+  assert.equal(viewSource.includes('openPluginCompatibilityDialog'), true)
   assert.equal(viewSource.includes('/api/plugins/compatibility-check/secspider'), true)
   assert.equal(viewSource.includes('checkPluginCompatibility'), true)
-  assert.equal(viewSource.includes('先点“兼容性校验”，看见门禁通过后再点“编译”'), true)
+  assert.equal(viewSource.includes('AI修复导出'), true)
+  assert.equal(viewSource.includes('把不合规项、需要修改的位置、修改意见和原始明文合并成 AI 更容易理解的文本'), true)
+  assert.equal(viewSource.includes('aiRepairExportText'), true)
+  assert.equal(viewSource.includes('先点“兼容性校验”打开独立门禁窗口'), true)
 })
 
 test('uses visual editor for subscription override instead of raw textarea', () => {

--- a/web-ui/src/views/SubscriptionsView.test.mjs
+++ b/web-ui/src/views/SubscriptionsView.test.mjs
@@ -34,6 +34,13 @@ test('accepts encrypted txt and raw Python plugin addresses', () => {
   assert.equal(viewSource.includes('placeholder="https://example.com/plugin.txt 或 plugin.py"'), true)
 })
 
+test('exposes compatibility gate entry in the plugin compiler dialog', () => {
+  assert.equal(viewSource.includes('兼容性校验'), true)
+  assert.equal(viewSource.includes('/api/plugins/compatibility-check/secspider'), true)
+  assert.equal(viewSource.includes('checkPluginCompatibility'), true)
+  assert.equal(viewSource.includes('先点“兼容性校验”，看见门禁通过后再点“编译”'), true)
+})
+
 test('uses visual editor for subscription override instead of raw textarea', () => {
   assert.equal(viewSource.includes('SubscriptionConfigEditor'), true)
   assert.equal(viewSource.includes("openEditor(false)"), true)

--- a/web-ui/src/views/SubscriptionsView.vue
+++ b/web-ui/src/views/SubscriptionsView.vue
@@ -338,6 +338,7 @@
           <el-button type="primary" :loading="importingPlugins" :disabled="!pluginImportForm.url.trim()" @click="importPlugins">
             导入仓库
           </el-button>
+          <el-button type="primary" @click="openPluginCompiler">三方插件编译</el-button>
         </el-form-item>
       </el-form>
       <el-progress v-if="importingPlugins" :percentage="100" :indeterminate="true" :duration="5"/>
@@ -586,6 +587,166 @@
         <span class="dialog-footer">
           <el-button @click="sourceExtendVisible = false">取消</el-button>
           <el-button type="primary" @click="saveSourceExtend">保存配置</el-button>
+        </span>
+      </template>
+    </el-dialog>
+
+    <el-dialog v-model="pluginCompilerVisible" title="三方插件编译" width="960px" destroy-on-close>
+      <el-collapse class="plugin-compiler-guide">
+        <el-collapse-item name="usage">
+          <template #title>
+            <span>使用说明与示例</span>
+          </template>
+          <div class="plugin-compiler-guide-body">
+            <ol>
+              <li>默认使用容器托管的 Ed25519 密钥对和 master secret，只需要把 Python 明文插件粘贴到“插件明文”。内层明文必须是合法 Python，不要写外层 <code>//@name</code> 这类包头。</li>
+              <li>容器首次启动会自动生成密钥文件，保存到 <code>/data/secspider</code>；只要 Docker 挂载的 <code>/data</code> 不丢，升级镜像后密钥仍然可用。</li>
+              <li>点击“编译”后会生成 <code>secspider/1</code> 插件包，自动保存到 <code>/www/static/self-plugins</code>，并自动导入插件管理列表。</li>
+              <li>如果需要更换密钥，使用“重置密钥对”。重置后旧密钥编译的自有插件需要重新编译。</li>
+              <li>需要强制只走自有 keyring 时，可在站点扩展配置里设置 <code>secspider_loader: self</code>；默认 <code>auto</code> 会先试原版再试自有。</li>
+            </ol>
+            <div class="plugin-compiler-example-grid">
+              <div>
+                <div class="plugin-compiler-example-title">明文插件示例</div>
+                <pre class="plugin-compiler-example">from base.spider import Spider
+
+class Spider(Spider):
+    def getName(self):
+        return "Demo"
+
+    def playerContent(self, flag, id, vipFlags):
+        return {"parse": 0, "url": id}</pre>
+              </div>
+              <div>
+                <div class="plugin-compiler-example-title">spiders_v2.json 示例</div>
+                <pre class="plugin-compiler-example">[
+  {
+    "id": "javbus_self",
+    "file": "py/javbus_self.txt",
+    "version": 1,
+    "valid": true
+  }
+]</pre>
+              </div>
+            </div>
+          </div>
+        </el-collapse-item>
+      </el-collapse>
+      <el-alert
+        v-if="secspiderKeyStatus"
+        type="success"
+        show-icon
+        :closable="false"
+        style="margin-bottom: 12px"
+      >
+        <template #title>
+          容器托管密钥已就绪：{{ secspiderKeyStatus.keyringPath }}
+        </template>
+      </el-alert>
+      <div class="plugin-compiler-key-actions">
+        <el-button type="primary" :loading="secspiderKeyLoading" @click="generateSecspiderKey">
+          生成密钥对
+        </el-button>
+        <el-button type="danger" :loading="secspiderKeyLoading" @click="resetSecspiderKey">
+          重置密钥对
+        </el-button>
+        <span class="plugin-compiler-key-hint">
+          私钥仅保存在容器数据目录；编译时后端自动读取，不会回显到页面。
+        </span>
+      </div>
+      <el-form :model="pluginCompilerForm" label-width="120px">
+        <el-form-item label="插件名称" required>
+          <el-input v-model="pluginCompilerForm.name" placeholder="例如 JavBus"/>
+        </el-form-item>
+        <el-form-item label="插件版本" required>
+          <el-input-number v-model="pluginCompilerForm.version" :min="1" :step="1"/>
+        </el-form-item>
+        <el-form-item label="插件 ID">
+          <el-input v-model="pluginCompilerForm.id" placeholder="稳定 id，可留空"/>
+        </el-form-item>
+        <el-form-item label="kid">
+          <el-input v-model="pluginCompilerForm.kid" placeholder="例如 self-20260716"/>
+        </el-form-item>
+        <el-form-item label="remark">
+          <el-input v-model="pluginCompilerForm.remark" placeholder="可留空"/>
+        </el-form-item>
+        <el-form-item label="托管密钥">
+          <el-switch v-model="pluginCompilerForm.useManagedKey" active-text="使用容器密钥" inactive-text="手动填写"/>
+        </el-form-item>
+        <el-form-item label="自动导入">
+          <el-switch v-model="pluginCompilerForm.autoImport" active-text="编译后导入插件管理" inactive-text="只生成包"/>
+        </el-form-item>
+        <el-form-item label="插件明文" required>
+          <el-input
+            v-model="pluginCompilerForm.source"
+            type="textarea"
+            :rows="9"
+            placeholder="粘贴 Python 明文插件源码"
+          />
+        </el-form-item>
+        <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="Ed25519 私钥" required>
+          <el-input
+            v-model="pluginCompilerForm.privateKey"
+            type="textarea"
+            :rows="4"
+            show-password
+            placeholder="PKCS8 PEM/base64，或 32 字节 raw seed 的 base64/hex"
+          />
+        </el-form-item>
+        <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="Ed25519 公钥">
+          <el-input
+            v-model="pluginCompilerForm.publicKey"
+            type="textarea"
+            :rows="3"
+            placeholder="可选。填写后返回 _self_public_key_chunks"
+          />
+        </el-form-item>
+        <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="master secret" required>
+          <el-input
+            v-model="pluginCompilerForm.masterSecret"
+            type="textarea"
+            :rows="2"
+            show-password
+            placeholder="自有 Atvp.py 中使用的 master secret"
+          />
+        </el-form-item>
+      </el-form>
+      <el-alert
+        title="默认使用容器托管密钥签名和加密。手动模式下，私钥只随本次请求发送到后端参与签名，接口不会保存或回显私钥。"
+        type="warning"
+        show-icon
+        :closable="false"
+        style="margin-bottom: 12px"
+      />
+      <div v-if="pluginCompilerResult">
+        <el-descriptions :column="3" border size="small" style="margin-bottom: 12px">
+          <el-descriptions-item label="格式">{{ pluginCompilerResult.format }}</el-descriptions-item>
+          <el-descriptions-item label="kid">{{ pluginCompilerResult.kid }}</el-descriptions-item>
+          <el-descriptions-item label="大小">{{ pluginCompilerResult.packageSize }}</el-descriptions-item>
+          <el-descriptions-item label="明文 SHA256" :span="3">{{ pluginCompilerResult.plainSha256 }}</el-descriptions-item>
+          <el-descriptions-item v-if="pluginCompilerResult.importedPluginId" label="已导入插件" :span="3">
+            #{{ pluginCompilerResult.importedPluginId }} {{ pluginCompilerResult.importedPluginName }}，
+            <a :href="pluginCompilerResult.pluginUrl" target="_blank">{{ pluginCompilerResult.pluginUrl }}</a>
+          </el-descriptions-item>
+          <el-descriptions-item v-if="pluginCompilerResult.repositoryUrl" label="自用仓库" :span="3">
+            <a :href="pluginCompilerResult.repositoryUrl" target="_blank">{{ pluginCompilerResult.repositoryUrl }}</a>
+          </el-descriptions-item>
+        </el-descriptions>
+        <el-tabs v-model="pluginCompilerResultTab">
+          <el-tab-pane label="插件包" name="package">
+            <el-input v-model="pluginCompilerResult.packageText" type="textarea" :rows="10"/>
+            <el-button style="margin-top: 8px" @click="copyUrl(pluginCompilerResult.packageText)">复制插件包</el-button>
+          </el-tab-pane>
+          <el-tab-pane label="Atvp chunks" name="chunks">
+            <el-input :model-value="pluginCompilerChunksText" type="textarea" :rows="10" readonly/>
+            <el-button style="margin-top: 8px" @click="copyUrl(pluginCompilerChunksText)">复制 chunks</el-button>
+          </el-tab-pane>
+        </el-tabs>
+      </div>
+      <template #footer>
+        <span class="dialog-footer">
+          <el-button @click="pluginCompilerVisible = false">关闭</el-button>
+          <el-button type="primary" :loading="pluginCompiling" @click="compilePlugin">编译</el-button>
         </span>
       </template>
     </el-dialog>
@@ -972,6 +1133,49 @@ interface PluginFilterExtraEntry {
   value: string
 }
 
+interface PluginCompileForm {
+  name: string
+  version: number
+  remark: string
+  id: string
+  kid: string
+  source: string
+  privateKey: string
+  publicKey: string
+  masterSecret: string
+  useManagedKey: boolean
+  autoImport: boolean
+}
+
+interface PluginCompileResult {
+  packageText: string
+  plainSha256: string
+  packageSize: number
+  format: string
+  alg: string
+  wrap: string
+  sign: string
+  kid: string
+  publicKeyChunks: string[]
+  masterSecretChunks: string[]
+  importedPluginId: number | null
+  importedPluginName: string
+  pluginUrl: string
+  repositoryUrl: string
+  localPath: string
+}
+
+interface SecspiderKeyStatus {
+  generated: boolean
+  privateKeyPath: string
+  publicKeyPath: string
+  masterSecretPath: string
+  keyringPath: string
+  publicKey: string
+  publicKeyChunks: string[]
+  masterSecretChunks: string[]
+}
+
 const PLUGIN_REPO_URL_KEY = 'plugin_repo_url'
 const currentUrl = window.location.origin
 const filterStageOptions = [
@@ -1041,10 +1245,14 @@ const rawJsonData = computed(() => JSON.stringify(jsonData.value, null, 2))
 const formVisible = ref(false)
 const dialogVisible = ref(false)
 const pluginVisible = ref(false)
+const pluginCompilerVisible = ref(false)
 const pluginFilterVisible = ref(false)
 const pluginFilterConfigVisible = ref(false)
 const sourceExtendVisible = ref(false)
 const importingPlugins = ref(false)
+const pluginCompiling = ref(false)
+const secspiderKeyLoading = ref(false)
+const secspiderKeyStatus = ref<SecspiderKeyStatus | null>(null)
 const tgVisible = ref(false)
 const scanVisible = ref(false)
 const confirm = ref(false)
@@ -1161,6 +1369,29 @@ const pluginForm = ref<Plugin>({
 })
 const pluginImportForm = ref({
   url: localStorage.getItem(PLUGIN_REPO_URL_KEY) || ''
+})
+const pluginCompilerForm = ref<PluginCompileForm>({
+  name: '',
+  version: 1,
+  remark: '',
+  id: '',
+  kid: 'self',
+  source: '',
+  privateKey: '',
+  publicKey: '',
+  masterSecret: '',
+  useManagedKey: true,
+  autoImport: true
+})
+const pluginCompilerResult = ref<PluginCompileResult | null>(null)
+const pluginCompilerResultTab = ref('package')
+const pluginCompilerChunksText = computed(() => {
+  if (!pluginCompilerResult.value) {
+    return ''
+  }
+  const publicKeyChunks = JSON.stringify(pluginCompilerResult.value.publicKeyChunks || [], null, 2)
+  const masterSecretChunks = JSON.stringify(pluginCompilerResult.value.masterSecretChunks || [], null, 2)
+  return `_self_public_key_chunks = ${publicKeyChunks}\n_self_master_secret_chunks = ${masterSecretChunks}`
 })
 const pluginSettingsForm = ref({
   githubProxy: '',
@@ -1308,6 +1539,24 @@ const resetPluginForm = () => {
     lastCheckedAt: '',
     lastError: ''
   }
+}
+
+const resetPluginCompilerForm = () => {
+  pluginCompilerForm.value = {
+    name: '',
+    version: 1,
+    remark: '',
+    id: '',
+    kid: 'self',
+    source: '',
+    privateKey: '',
+    publicKey: '',
+    masterSecret: '',
+    useManagedKey: true,
+    autoImport: true
+  }
+  pluginCompilerResult.value = null
+  pluginCompilerResultTab.value = 'package'
 }
 
 const parsePluginFilterStages = (value: string) => {
@@ -2395,6 +2644,44 @@ const showPlugins = () => {
   loadPluginSettings()
 }
 
+const openPluginCompiler = () => {
+  resetPluginCompilerForm()
+  pluginCompilerVisible.value = true
+  loadSecspiderKeyStatus()
+}
+
+const loadSecspiderKeyStatus = async () => {
+  secspiderKeyLoading.value = true
+  try {
+    const {data} = await axios.get('/api/plugins/secspider/key')
+    secspiderKeyStatus.value = data
+  } finally {
+    secspiderKeyLoading.value = false
+  }
+}
+
+const generateSecspiderKey = async () => {
+  secspiderKeyLoading.value = true
+  try {
+    const {data} = await axios.post('/api/plugins/secspider/key/generate')
+    secspiderKeyStatus.value = data
+    ElMessage.success('密钥对已就绪')
+  } finally {
+    secspiderKeyLoading.value = false
+  }
+}
+
+const resetSecspiderKey = async () => {
+  secspiderKeyLoading.value = true
+  try {
+    const {data} = await axios.post('/api/plugins/secspider/key/reset')
+    secspiderKeyStatus.value = data
+    ElMessage.warning('密钥对已重置，旧自有插件需要重新编译')
+  } finally {
+    secspiderKeyLoading.value = false
+  }
+}
+
 const showPluginFilters = () => {
   pluginFilterVisible.value = true
   resetPluginFilterForm()
@@ -2440,6 +2727,51 @@ const importPlugins = async () => {
     loadManagedSources()
   } finally {
     importingPlugins.value = false
+  }
+}
+
+const compilePlugin = async () => {
+  const form = pluginCompilerForm.value
+  if (!form.name.trim()) {
+    ElMessage.warning('请输入插件名称')
+    return
+  }
+  if (!form.source.trim()) {
+    ElMessage.warning('请粘贴插件明文')
+    return
+  }
+  if (!form.useManagedKey && !form.privateKey.trim()) {
+    ElMessage.warning('请粘贴 Ed25519 私钥')
+    return
+  }
+  if (!form.useManagedKey && !form.masterSecret.trim()) {
+    ElMessage.warning('请填写 master secret')
+    return
+  }
+
+  pluginCompiling.value = true
+  try {
+    const {data} = await axios.post('/api/plugins/compile/secspider', {
+      name: form.name.trim(),
+      version: form.version,
+      remark: form.remark,
+      id: form.id.trim(),
+      kid: form.kid.trim(),
+      source: form.source,
+      privateKey: form.privateKey,
+      publicKey: form.publicKey,
+      masterSecret: form.masterSecret,
+      useManagedKey: form.useManagedKey,
+      autoImport: form.autoImport
+    })
+    pluginCompilerResult.value = data
+    pluginCompilerResultTab.value = 'package'
+    ElMessage.success(data.importedPluginId ? '编译完成，已自动导入插件管理' : '编译完成')
+    if (data.importedPluginId) {
+      loadManagedSources()
+    }
+  } finally {
+    pluginCompiling.value = false
   }
 }
 
@@ -2871,6 +3203,62 @@ onUnmounted(() => {
 .filter-config-extra-empty {
   color: var(--el-text-color-secondary);
   font-size: 13px;
+}
+
+.plugin-compiler-guide {
+  margin-bottom: 14px;
+}
+
+.plugin-compiler-key-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.plugin-compiler-key-hint {
+  color: var(--el-text-color-secondary);
+  font-size: 13px;
+}
+
+.plugin-compiler-guide-body {
+  color: var(--el-text-color-regular);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.plugin-compiler-guide-body ol {
+  margin: 0 0 12px 20px;
+  padding: 0;
+}
+
+.plugin-compiler-example-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.plugin-compiler-example-title {
+  color: var(--el-text-color-primary);
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.plugin-compiler-example {
+  background: var(--el-fill-color-light);
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  margin: 0;
+  overflow: auto;
+  padding: 10px;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 900px) {
+  .plugin-compiler-example-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .json pre {

--- a/web-ui/src/views/SubscriptionsView.vue
+++ b/web-ui/src/views/SubscriptionsView.vue
@@ -600,6 +600,7 @@
           <div class="plugin-compiler-guide-body">
             <ol>
               <li>默认使用容器托管的 Ed25519 密钥对和 master secret，只需要把 Python 明文插件粘贴到“插件明文”。内层明文必须是合法 Python，不要写外层 <code>//@name</code> 这类包头。</li>
+              <li>先点“兼容性校验”，看见门禁通过后再点“编译”；不合规项会直接列出来。</li>
               <li>容器首次启动会自动生成密钥文件，保存到 <code>/data/secspider</code>；只要 Docker 挂载的 <code>/data</code> 不丢，升级镜像后密钥仍然可用。</li>
               <li>点击“编译”后会生成 <code>secspider/1</code> 插件包，自动保存到 <code>/www/static/self-plugins</code>，并自动导入插件管理列表。</li>
               <li><code>ext.source</code>、<code>token</code>、<code>local_proxy_config</code> 和 <code>ext.data</code> 都由容器上下文自动补齐；原版插件通常只需要源码本身。</li>
@@ -735,6 +736,37 @@ class Spider(Spider):
         :closable="false"
         style="margin-bottom: 12px"
       />
+      <div v-if="pluginCompatibilityResult" style="margin-bottom: 12px">
+        <el-alert
+          :title="pluginCompatibilityResult.summary"
+          :type="pluginCompatibilityResult.passed ? 'success' : 'error'"
+          show-icon
+          :closable="false"
+          style="margin-bottom: 12px"
+        />
+        <el-descriptions :column="4" border size="small" style="margin-bottom: 12px">
+          <el-descriptions-item label="通过项">{{ pluginCompatibilityResult.passCount }}</el-descriptions-item>
+          <el-descriptions-item label="不合规项">{{ pluginCompatibilityResult.failCount }}</el-descriptions-item>
+          <el-descriptions-item label="结果">{{ pluginCompatibilityResult.passed ? '通过' : '未通过' }}</el-descriptions-item>
+          <el-descriptions-item label="门禁">{{ pluginCompatibilityResult.gateName }}</el-descriptions-item>
+          <el-descriptions-item label="目标" :span="2">{{ pluginCompatibilityResult.pluginName }} (#{{ pluginCompatibilityResult.pluginId }})</el-descriptions-item>
+          <el-descriptions-item label="版本">{{ pluginCompatibilityResult.version }}</el-descriptions-item>
+          <el-descriptions-item label="明文 SHA256" :span="3">{{ pluginCompatibilityResult.sourceSha256 }}</el-descriptions-item>
+        </el-descriptions>
+        <el-table :data="pluginCompatibilityResult.items" border size="small">
+          <el-table-column label="状态" width="90">
+            <template #default="scope">
+              <el-tag :type="scope.row.status === 'PASS' ? 'success' : 'danger'">
+                {{ scope.row.status === 'PASS' ? '通过' : '不合规' }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column prop="title" label="检查项" width="160"/>
+          <el-table-column prop="message" label="结果说明" min-width="240"/>
+          <el-table-column prop="suggestion" label="建议" min-width="260"/>
+          <el-table-column prop="code" label="Code" width="160"/>
+        </el-table>
+      </div>
       <div v-if="pluginCompilerResult">
         <el-descriptions :column="3" border size="small" style="margin-bottom: 12px">
           <el-descriptions-item label="格式">{{ pluginCompilerResult.format }}</el-descriptions-item>
@@ -763,6 +795,7 @@ class Spider(Spider):
       <template #footer>
         <span class="dialog-footer">
           <el-button @click="pluginCompilerVisible = false">关闭</el-button>
+          <el-button :loading="pluginCompatibilityLoading" @click="checkPluginCompatibility">兼容性校验</el-button>
           <el-button type="primary" :loading="pluginCompiling" @click="compilePlugin">编译</el-button>
         </span>
       </template>
@@ -1182,6 +1215,27 @@ interface PluginCompileResult {
   localPath: string
 }
 
+interface PluginCompatibilityItem {
+  code: string
+  title: string
+  status: 'PASS' | 'FAIL'
+  message: string
+  suggestion: string
+}
+
+interface PluginCompatibilityResult {
+  gateName: string
+  pluginName: string
+  pluginId: string
+  version: number
+  sourceSha256: string
+  passed: boolean
+  passCount: number
+  failCount: number
+  summary: string
+  items: PluginCompatibilityItem[]
+}
+
 interface SecspiderKeyStatus {
   generated: boolean
   privateKeyPath: string
@@ -1268,6 +1322,8 @@ const pluginFilterConfigVisible = ref(false)
 const sourceExtendVisible = ref(false)
 const importingPlugins = ref(false)
 const pluginCompiling = ref(false)
+const pluginCompatibilityLoading = ref(false)
+const pluginCompatibilityResult = ref<PluginCompatibilityResult | null>(null)
 const secspiderKeyLoading = ref(false)
 const secspiderKeyStatus = ref<SecspiderKeyStatus | null>(null)
 const tgVisible = ref(false)
@@ -1574,6 +1630,7 @@ const resetPluginCompilerForm = () => {
     autoImport: true
   }
   pluginCompilerAdvancedPanels.value = []
+  pluginCompatibilityResult.value = null
   pluginCompilerResult.value = null
   pluginCompilerResultTab.value = 'package'
 }
@@ -2791,6 +2848,37 @@ const compilePlugin = async () => {
     }
   } finally {
     pluginCompiling.value = false
+  }
+}
+
+const checkPluginCompatibility = async () => {
+  const form = pluginCompilerForm.value
+  if (!form.name.trim()) {
+    ElMessage.warning('请输入插件名称')
+    return
+  }
+  if (!form.source.trim()) {
+    ElMessage.warning('请粘贴插件明文')
+    return
+  }
+
+  pluginCompatibilityLoading.value = true
+  try {
+    const {data} = await axios.post('/api/plugins/compatibility-check/secspider', {
+      name: form.name.trim(),
+      version: form.version,
+      remark: form.remark,
+      id: form.id.trim(),
+      source: form.source
+    })
+    pluginCompatibilityResult.value = data
+    if (data.passed) {
+      ElMessage.success('兼容性校验通过')
+    } else {
+      ElMessage.error(`发现 ${data.failCount} 项不合规`)
+    }
+  } finally {
+    pluginCompatibilityLoading.value = false
   }
 }
 

--- a/web-ui/src/views/SubscriptionsView.vue
+++ b/web-ui/src/views/SubscriptionsView.vue
@@ -600,7 +600,7 @@
           <div class="plugin-compiler-guide-body">
             <ol>
               <li>默认使用容器托管的 Ed25519 密钥对和 master secret，只需要把 Python 明文插件粘贴到“插件明文”。内层明文必须是合法 Python，不要写外层 <code>//@name</code> 这类包头。</li>
-              <li>先点“兼容性校验”，看见门禁通过后再点“编译”；不合规项会直接列出来。</li>
+              <li>先点“兼容性校验”打开独立门禁窗口，看见门禁通过后再点“编译”；不合规项和 AI 修复导出会直接列出来。</li>
               <li>容器首次启动会自动生成密钥文件，保存到 <code>/data/secspider</code>；只要 Docker 挂载的 <code>/data</code> 不丢，升级镜像后密钥仍然可用。</li>
               <li>点击“编译”后会生成 <code>secspider/1</code> 插件包，自动保存到 <code>/www/static/self-plugins</code>，并自动导入插件管理列表。</li>
               <li><code>ext.source</code>、<code>token</code>、<code>local_proxy_config</code> 和 <code>ext.data</code> 都由容器上下文自动补齐；原版插件通常只需要源码本身。</li>
@@ -736,37 +736,6 @@ class Spider(Spider):
         :closable="false"
         style="margin-bottom: 12px"
       />
-      <div v-if="pluginCompatibilityResult" style="margin-bottom: 12px">
-        <el-alert
-          :title="pluginCompatibilityResult.summary"
-          :type="pluginCompatibilityResult.passed ? 'success' : 'error'"
-          show-icon
-          :closable="false"
-          style="margin-bottom: 12px"
-        />
-        <el-descriptions :column="4" border size="small" style="margin-bottom: 12px">
-          <el-descriptions-item label="通过项">{{ pluginCompatibilityResult.passCount }}</el-descriptions-item>
-          <el-descriptions-item label="不合规项">{{ pluginCompatibilityResult.failCount }}</el-descriptions-item>
-          <el-descriptions-item label="结果">{{ pluginCompatibilityResult.passed ? '通过' : '未通过' }}</el-descriptions-item>
-          <el-descriptions-item label="门禁">{{ pluginCompatibilityResult.gateName }}</el-descriptions-item>
-          <el-descriptions-item label="目标" :span="2">{{ pluginCompatibilityResult.pluginName }} (#{{ pluginCompatibilityResult.pluginId }})</el-descriptions-item>
-          <el-descriptions-item label="版本">{{ pluginCompatibilityResult.version }}</el-descriptions-item>
-          <el-descriptions-item label="明文 SHA256" :span="3">{{ pluginCompatibilityResult.sourceSha256 }}</el-descriptions-item>
-        </el-descriptions>
-        <el-table :data="pluginCompatibilityResult.items" border size="small">
-          <el-table-column label="状态" width="90">
-            <template #default="scope">
-              <el-tag :type="scope.row.status === 'PASS' ? 'success' : 'danger'">
-                {{ scope.row.status === 'PASS' ? '通过' : '不合规' }}
-              </el-tag>
-            </template>
-          </el-table-column>
-          <el-table-column prop="title" label="检查项" width="160"/>
-          <el-table-column prop="message" label="结果说明" min-width="240"/>
-          <el-table-column prop="suggestion" label="建议" min-width="260"/>
-          <el-table-column prop="code" label="Code" width="160"/>
-        </el-table>
-      </div>
       <div v-if="pluginCompilerResult">
         <el-descriptions :column="3" border size="small" style="margin-bottom: 12px">
           <el-descriptions-item label="格式">{{ pluginCompilerResult.format }}</el-descriptions-item>
@@ -795,8 +764,93 @@ class Spider(Spider):
       <template #footer>
         <span class="dialog-footer">
           <el-button @click="pluginCompilerVisible = false">关闭</el-button>
-          <el-button :loading="pluginCompatibilityLoading" @click="checkPluginCompatibility">兼容性校验</el-button>
+          <el-button @click="openPluginCompatibilityDialog">兼容性校验</el-button>
           <el-button type="primary" :loading="pluginCompiling" @click="compilePlugin">编译</el-button>
+        </span>
+      </template>
+    </el-dialog>
+
+    <el-dialog v-model="pluginCompatibilityVisible" title="兼容性校验" width="1040px" destroy-on-close>
+      <el-alert
+        title="磁力爬虫门禁独立校验，不直接修改三方插件编译区的明文；需要回填时请复制 AI 修复后的源码。"
+        type="info"
+        show-icon
+        :closable="false"
+        style="margin-bottom: 12px"
+      />
+      <el-form :model="pluginCompatibilityForm" label-width="120px">
+        <el-form-item label="插件名称" required>
+          <el-input v-model="pluginCompatibilityForm.name" placeholder="例如 JavBus"/>
+        </el-form-item>
+        <el-form-item label="插件版本" required>
+          <el-input-number v-model="pluginCompatibilityForm.version" :min="1" :step="1"/>
+        </el-form-item>
+        <el-form-item label="插件 ID">
+          <el-input v-model="pluginCompatibilityForm.id" placeholder="可留空，按名称自动推导"/>
+        </el-form-item>
+        <el-form-item label="remark">
+          <el-input v-model="pluginCompatibilityForm.remark" placeholder="可留空"/>
+        </el-form-item>
+        <el-form-item label="校验明文" required>
+          <el-input
+            v-model="pluginCompatibilityForm.source"
+            type="textarea"
+            :rows="12"
+            placeholder="粘贴要校验的 Python 明文插件源码"
+          />
+        </el-form-item>
+      </el-form>
+      <div v-if="pluginCompatibilityResult" style="margin-bottom: 12px">
+        <el-alert
+          :title="pluginCompatibilityResult.summary"
+          :type="pluginCompatibilityResult.passed ? 'success' : 'error'"
+          show-icon
+          :closable="false"
+          style="margin-bottom: 12px"
+        />
+        <el-descriptions :column="4" border size="small" style="margin-bottom: 12px">
+          <el-descriptions-item label="通过项">{{ pluginCompatibilityResult.passCount }}</el-descriptions-item>
+          <el-descriptions-item label="不合规项">{{ pluginCompatibilityResult.failCount }}</el-descriptions-item>
+          <el-descriptions-item label="结果">{{ pluginCompatibilityResult.passed ? '通过' : '未通过' }}</el-descriptions-item>
+          <el-descriptions-item label="门禁">{{ pluginCompatibilityResult.gateName }}</el-descriptions-item>
+          <el-descriptions-item label="目标" :span="2">{{ pluginCompatibilityResult.pluginName }} (#{{ pluginCompatibilityResult.pluginId }})</el-descriptions-item>
+          <el-descriptions-item label="版本">{{ pluginCompatibilityResult.version }}</el-descriptions-item>
+          <el-descriptions-item label="明文 SHA256" :span="3">{{ pluginCompatibilityResult.sourceSha256 }}</el-descriptions-item>
+        </el-descriptions>
+        <el-tabs v-model="pluginCompatibilityResultTab">
+          <el-tab-pane label="校验结果" name="result">
+            <el-table :data="pluginCompatibilityResult.items" border size="small">
+              <el-table-column label="状态" width="90">
+                <template #default="scope">
+                  <el-tag :type="scope.row.status === 'PASS' ? 'success' : 'danger'">
+                    {{ scope.row.status === 'PASS' ? '通过' : '不合规' }}
+                  </el-tag>
+                </template>
+              </el-table-column>
+              <el-table-column prop="title" label="检查项" width="160"/>
+              <el-table-column prop="message" label="结果说明" min-width="240"/>
+              <el-table-column prop="suggestion" label="修改意见" min-width="260"/>
+              <el-table-column prop="code" label="Code" width="160"/>
+            </el-table>
+          </el-tab-pane>
+          <el-tab-pane label="AI修复导出" name="aiRepair">
+            <el-alert
+              title="AI修复导出会把不合规项、需要修改的位置、修改意见和原始明文合并成 AI 更容易理解的文本。把这段内容提交给 AI 修复脚本后，再把修复后的明文拿回来重新做兼容性校验。"
+              type="info"
+              show-icon
+              :closable="false"
+              style="margin-bottom: 12px"
+            />
+            <el-input :model-value="pluginCompatibilityResult.aiRepairExportText" type="textarea" :rows="14" readonly/>
+            <el-button style="margin-top: 8px" @click="copyUrl(pluginCompatibilityResult.aiRepairExportText)">复制 AI 修复导出</el-button>
+          </el-tab-pane>
+        </el-tabs>
+      </div>
+      <template #footer>
+        <span class="dialog-footer">
+          <el-button @click="pluginCompatibilityVisible = false">关闭</el-button>
+          <el-button @click="loadCompatibilityFromCompiler">从编译区同步一次</el-button>
+          <el-button type="primary" :loading="pluginCompatibilityLoading" @click="checkPluginCompatibility">开始校验</el-button>
         </span>
       </template>
     </el-dialog>
@@ -1197,6 +1251,14 @@ interface PluginCompileForm {
   autoImport: boolean
 }
 
+interface PluginCompatibilityForm {
+  name: string
+  version: number
+  remark: string
+  id: string
+  source: string
+}
+
 interface PluginCompileResult {
   packageText: string
   plainSha256: string
@@ -1234,6 +1296,7 @@ interface PluginCompatibilityResult {
   failCount: number
   summary: string
   items: PluginCompatibilityItem[]
+  aiRepairExportText: string
 }
 
 interface SecspiderKeyStatus {
@@ -1317,6 +1380,7 @@ const formVisible = ref(false)
 const dialogVisible = ref(false)
 const pluginVisible = ref(false)
 const pluginCompilerVisible = ref(false)
+const pluginCompatibilityVisible = ref(false)
 const pluginFilterVisible = ref(false)
 const pluginFilterConfigVisible = ref(false)
 const sourceExtendVisible = ref(false)
@@ -1456,9 +1520,17 @@ const pluginCompilerForm = ref<PluginCompileForm>({
   useManagedKey: true,
   autoImport: true
 })
+const pluginCompatibilityForm = ref<PluginCompatibilityForm>({
+  name: '',
+  version: 1,
+  remark: '',
+  id: '',
+  source: ''
+})
 const pluginCompilerResult = ref<PluginCompileResult | null>(null)
 const pluginCompilerResultTab = ref('package')
 const pluginCompilerAdvancedPanels = ref<string[]>([])
+const pluginCompatibilityResultTab = ref('result')
 const pluginCompilerChunksText = computed(() => {
   if (!pluginCompilerResult.value) {
     return ''
@@ -2726,6 +2798,24 @@ const openPluginCompiler = () => {
   loadSecspiderKeyStatus()
 }
 
+const loadCompatibilityFromCompiler = () => {
+  const form = pluginCompilerForm.value
+  pluginCompatibilityForm.value = {
+    name: form.name,
+    version: form.version,
+    remark: form.remark,
+    id: form.id,
+    source: form.source
+  }
+  pluginCompatibilityResult.value = null
+  pluginCompatibilityResultTab.value = 'result'
+}
+
+const openPluginCompatibilityDialog = () => {
+  loadCompatibilityFromCompiler()
+  pluginCompatibilityVisible.value = true
+}
+
 const loadSecspiderKeyStatus = async () => {
   secspiderKeyLoading.value = true
   try {
@@ -2852,7 +2942,7 @@ const compilePlugin = async () => {
 }
 
 const checkPluginCompatibility = async () => {
-  const form = pluginCompilerForm.value
+  const form = pluginCompatibilityForm.value
   if (!form.name.trim()) {
     ElMessage.warning('请输入插件名称')
     return
@@ -2872,6 +2962,7 @@ const checkPluginCompatibility = async () => {
       source: form.source
     })
     pluginCompatibilityResult.value = data
+    pluginCompatibilityResultTab.value = data.passed ? 'result' : 'aiRepair'
     if (data.passed) {
       ElMessage.success('兼容性校验通过')
     } else {

--- a/web-ui/src/views/SubscriptionsView.vue
+++ b/web-ui/src/views/SubscriptionsView.vue
@@ -602,6 +602,7 @@
               <li>默认使用容器托管的 Ed25519 密钥对和 master secret，只需要把 Python 明文插件粘贴到“插件明文”。内层明文必须是合法 Python，不要写外层 <code>//@name</code> 这类包头。</li>
               <li>容器首次启动会自动生成密钥文件，保存到 <code>/data/secspider</code>；只要 Docker 挂载的 <code>/data</code> 不丢，升级镜像后密钥仍然可用。</li>
               <li>点击“编译”后会生成 <code>secspider/1</code> 插件包，自动保存到 <code>/www/static/self-plugins</code>，并自动导入插件管理列表。</li>
+              <li><code>ext.source</code>、<code>token</code>、<code>local_proxy_config</code> 和 <code>ext.data</code> 都由容器上下文自动补齐；原版插件通常只需要源码本身。</li>
               <li>如果需要更换密钥，使用“重置密钥对”。重置后旧密钥编译的自有插件需要重新编译。</li>
               <li>需要强制只走自有 keyring 时，可在站点扩展配置里设置 <code>secspider_loader: self</code>；默认 <code>auto</code> 会先试原版再试自有。</li>
             </ol>
@@ -661,17 +662,8 @@ class Spider(Spider):
         <el-form-item label="插件版本" required>
           <el-input-number v-model="pluginCompilerForm.version" :min="1" :step="1"/>
         </el-form-item>
-        <el-form-item label="插件 ID">
-          <el-input v-model="pluginCompilerForm.id" placeholder="稳定 id，可留空"/>
-        </el-form-item>
-        <el-form-item label="kid">
-          <el-input v-model="pluginCompilerForm.kid" placeholder="例如 self-20260716"/>
-        </el-form-item>
         <el-form-item label="remark">
           <el-input v-model="pluginCompilerForm.remark" placeholder="可留空"/>
-        </el-form-item>
-        <el-form-item label="托管密钥">
-          <el-switch v-model="pluginCompilerForm.useManagedKey" active-text="使用容器密钥" inactive-text="手动填写"/>
         </el-form-item>
         <el-form-item label="自动导入">
           <el-switch v-model="pluginCompilerForm.autoImport" active-text="编译后导入插件管理" inactive-text="只生成包"/>
@@ -684,32 +676,57 @@ class Spider(Spider):
             placeholder="粘贴 Python 明文插件源码"
           />
         </el-form-item>
-        <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="Ed25519 私钥" required>
-          <el-input
-            v-model="pluginCompilerForm.privateKey"
-            type="textarea"
-            :rows="4"
-            show-password
-            placeholder="PKCS8 PEM/base64，或 32 字节 raw seed 的 base64/hex"
-          />
-        </el-form-item>
-        <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="Ed25519 公钥">
-          <el-input
-            v-model="pluginCompilerForm.publicKey"
-            type="textarea"
-            :rows="3"
-            placeholder="可选。填写后返回 _self_public_key_chunks"
-          />
-        </el-form-item>
-        <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="master secret" required>
-          <el-input
-            v-model="pluginCompilerForm.masterSecret"
-            type="textarea"
-            :rows="2"
-            show-password
-            placeholder="自有 Atvp.py 中使用的 master secret"
-          />
-        </el-form-item>
+        <el-collapse v-model="pluginCompilerAdvancedPanels" class="plugin-compiler-advanced">
+          <el-collapse-item name="advanced">
+            <template #title>
+              <span>高级手动参数</span>
+            </template>
+            <div class="plugin-compiler-advanced-body">
+              <el-form-item label="插件 ID">
+                <el-input v-model="pluginCompilerForm.id" placeholder="可留空，按名称自动推导"/>
+              </el-form-item>
+              <el-form-item label="kid">
+                <el-input v-model="pluginCompilerForm.kid" placeholder="可留空，默认 self"/>
+              </el-form-item>
+              <el-form-item label="托管密钥">
+                <el-switch v-model="pluginCompilerForm.useManagedKey" active-text="使用容器密钥" inactive-text="手动填写"/>
+              </el-form-item>
+              <el-alert
+                title="默认建议保持容器密钥。只有你要复用外部自有 keyring 时，才打开下面的手动字段。"
+                type="info"
+                :closable="false"
+                show-icon
+                style="margin-bottom: 12px"
+              />
+              <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="Ed25519 私钥" required>
+                <el-input
+                  v-model="pluginCompilerForm.privateKey"
+                  type="textarea"
+                  :rows="4"
+                  show-password
+                  placeholder="PKCS8 PEM/base64，或 32 字节 raw seed 的 base64/hex"
+                />
+              </el-form-item>
+              <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="Ed25519 公钥">
+                <el-input
+                  v-model="pluginCompilerForm.publicKey"
+                  type="textarea"
+                  :rows="3"
+                  placeholder="可选。填写后返回 _self_public_key_chunks"
+                />
+              </el-form-item>
+              <el-form-item v-if="!pluginCompilerForm.useManagedKey" label="master secret" required>
+                <el-input
+                  v-model="pluginCompilerForm.masterSecret"
+                  type="textarea"
+                  :rows="2"
+                  show-password
+                  placeholder="自有 Atvp.py 中使用的 master secret"
+                />
+              </el-form-item>
+            </div>
+          </el-collapse-item>
+        </el-collapse>
       </el-form>
       <el-alert
         title="默认使用容器托管密钥签名和加密。手动模式下，私钥只随本次请求发送到后端参与签名，接口不会保存或回显私钥。"
@@ -1385,6 +1402,7 @@ const pluginCompilerForm = ref<PluginCompileForm>({
 })
 const pluginCompilerResult = ref<PluginCompileResult | null>(null)
 const pluginCompilerResultTab = ref('package')
+const pluginCompilerAdvancedPanels = ref<string[]>([])
 const pluginCompilerChunksText = computed(() => {
   if (!pluginCompilerResult.value) {
     return ''
@@ -1555,6 +1573,7 @@ const resetPluginCompilerForm = () => {
     useManagedKey: true,
     autoImport: true
   }
+  pluginCompilerAdvancedPanels.value = []
   pluginCompilerResult.value = null
   pluginCompilerResultTab.value = 'package'
 }


### PR DESCRIPTION
## 概要

这次 PR 增加了托管式第三方 secspider 插件编译流程，以及一套面向磁力类 Python 爬虫的兼容性校验门禁。

- 在容器数据目录下生成并保存托管用的 Ed25519 主密钥和 master secret，不把私钥提交到仓库
- 支持 `secspider/1` 插件编译、静态自用插件仓库输出，以及可选的自动导入插件管理
- 保持原有 ATVP / secspider 加载兼容，同时增加自有 keyring 回退
- 由容器和订阅上下文自动补齐插件 `ext` 参数，减少部署时手动填写出错
- 增加独立的“兼容性校验”弹窗，用来做磁力爬虫门禁检查
- 增加“AI 修复导出”结果，把不合规项、修改建议和源码整理成便于 AI 理解的文本，方便修复后再校验

## 安全边界

- 不包含个人镜像发布流程
- 不包含私有服务器地址、token、密码、本地路径或 GHCR 用户信息
- 托管密钥仅保留在容器本地，不会在 WebUI 中回显
- 保留了上游 1.22.0 的原生 Python 插件支持

## 测试

- `.\\mvnw.cmd "-Dtest=PluginCompilerCompatibilityTest,PluginControllerCompatibilityCheckTest" -DfailIfNoTests=false -DforkCount=0 test`
- `node --test D:\\alist\\alist-tvbox-pr-20260719\\web-ui\\src\\views\\SubscriptionsView.test.mjs`
- `npm run type-check`
- `git diff --check`

## 备注

PR 分支已经基于当前上游 `master`（`e9f19ea3`）重新整理，且刻意排除了仅供私有验证使用的 fork 专属 Docker 发布流程。
