### PR TITLE
fix(tvbox): correct media name extraction for season folders

### DIFF
--- a/src/main/java/cn/har01d/alist_tvbox/service/DoubanService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/DoubanService.java
@@ -77,6 +77,8 @@ public class DoubanService {
     private static final Pattern NUMBER1 = Pattern.compile("第(\\d{1,2})季");
     private static final Pattern YEAR_PATTERN = Pattern.compile("\\((\\d{4})\\)");
     private static final Pattern YEAR2_PATTERN = Pattern.compile("(\\d{4})");
+    // matches a whole string that is only a season marker (第一季, 第3季, Season 1, S01)
+    private static final Pattern SEASON_ONLY = Pattern.compile("^第[0-9一二三四五六七八九十百零两]+季$|^Season\\s+\\d{1,2}$|^S\\d{1,2}$|^SE\\d{1,2}$");
     private static final String DB_PREFIX = "https://movie.douban.com/subject/";
     private static final String[] tokens = new String[]{"导演:", "编剧:", "主演:", "类型:", "制片国家/地区:", "语言:", "上映日期:",
             "片长:", "又名:", "IMDb链接:", "官方网站:", "官方小站:", "首播:", "季数:", "集数:", "单集片长:"};
@@ -432,7 +434,7 @@ public class DoubanService {
                 return alias.getMovie();
             }
 
-            name = TextUtils.fixName(name);
+            name = TextUtils.collapseCjkSpaces(TextUtils.fixName(name));
             if (name.isEmpty()) {
                 return null;
             }
@@ -466,8 +468,10 @@ public class DoubanService {
             }
 
             // no exact-name match: fall back to name-contains scoped by the extracted
-            // year, then pick the best-matching name (exact > shortest > first)
-            if (year != null) {
+            // year, then pick the best-matching name (exact > shortest > first).
+            // Skip for a bare season token (第一季/Season 1/S01): it is not a title and
+            // the LIKE would match every season-N show of that year (wrong title).
+            if (year != null && !isSeasonOnly(name)) {
                 return pickBestName(movieRepository.findByYearAndNameContains(year, name, Pageable.ofSize(10)).getContent(), name);
             }
         } catch (Exception e) {
@@ -500,6 +504,12 @@ public class DoubanService {
             }
         }
         return best != null ? best : movies.get(0);
+    }
+
+    // true when the (already fixName'd) search key is only a season marker, i.e. not a
+    // discriminative title. Used to skip the year-scoped name-contains fallback.
+    static boolean isSeasonOnly(String name) {
+        return name != null && SEASON_ONLY.matcher(name).matches();
     }
 
     // among name-contains candidates, prefer an exact name, else the shortest name

--- a/src/main/java/cn/har01d/alist_tvbox/service/TvBoxService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/TvBoxService.java
@@ -2413,6 +2413,15 @@ public class TvBoxService {
                         String newName = getNameFromPath(getParent(path));
                         if (!newName.equals(name) && !DriveId.isShareTokenName(newName)) {
                             movie = doubanService.getByName(newName, year);
+                            if (movie == null && details) {
+                                // No Douban entry for this show; surface the show name
+                                // derived from the parent folder instead of leaving the
+                                // bare season token (e.g. "S01" -> "百.花.杀（2026）" -> "百花杀").
+                                String showName = TextUtils.collapseCjkSpaces(TextUtils.fixName(newName));
+                                if (StringUtils.isNotBlank(showName) && !excludeNames.contains(showName)) {
+                                    movieDetail.setVod_name(showName);
+                                }
+                            }
                             break;
                         }
                     }
@@ -2447,7 +2456,7 @@ public class TvBoxService {
         if (!details) {
             return;
         }
-        if (movieDetail.getVod_id().endsWith("playlist$1")) {
+        if (movieDetail.getPath() != null && movieDetail.getPath().contains(PLAYLIST)) {
             movieDetail.setVod_name(movie.getName());
         }
         movieDetail.setVod_actor(movie.getActors());
@@ -2498,7 +2507,7 @@ public class TvBoxService {
         if (!details) {
             return;
         }
-        if (movieDetail.getVod_id().endsWith("playlist$1")) {
+        if (movieDetail.getPath() != null && movieDetail.getPath().contains(PLAYLIST)) {
             movieDetail.setVod_name(movie.getName());
         }
         movieDetail.setVod_actor(movie.getActors());

--- a/src/main/java/cn/har01d/alist_tvbox/util/TextUtils.java
+++ b/src/main/java/cn/har01d/alist_tvbox/util/TextUtils.java
@@ -589,6 +589,18 @@ public class TextUtils {
         return newName;
     }
 
+    // Uploaders often dot-separate CJK characters to evade detection ("百.花.杀").
+    // fixName turns those dots into spaces, so the key becomes "百 花 杀" and no longer
+    // matches the real title "百花杀" stored without spaces. Collapse whitespace between
+    // Han characters so such names resolve. Applied deliberately, not inside fixName:
+    // legitimate names like "重紫 第10季" rely on the separating space.
+    public static String collapseCjkSpaces(String name) {
+        if (name == null) {
+            return null;
+        }
+        return name.replaceAll("(?<=[\\u4e00-\\u9fa5])\\s+(?=[\\u4e00-\\u9fa5])", "");
+    }
+
     public static String number2text(String text) {
         if (text.startsWith("0") && text.length() > 1) {
             text = text.substring(1);

--- a/src/main/resources/static/Atvp.py
+++ b/src/main/resources/static/Atvp.py
@@ -690,10 +690,41 @@ class Spider(HostSpider):
 
     def _decode_parse(self, vod_id):
         value = str(vod_id or "").strip()
+        if value.startswith(self.PUSH_PREFIX):
+            value = value[len(self.PUSH_PREFIX):].strip()
         if (value.startswith("http://") or value.startswith("https://")
                 or value.startswith("magnet:") or value.startswith("ed2k:")):
             return value
         return None
+
+    def _resolve_deferred_share_url(self, source_id, share_url):
+        original = str(share_url or "").strip()
+        context = self._lookup_play_context(source_id)
+        play_id = str(context.get("play_id") or "").strip()
+        if not play_id.startswith(self.PUSH_PREFIX):
+            return original
+
+        player = getattr(self._require_inner(), "playerContent", None)
+        if not callable(player):
+            return original
+        try:
+            result = player(str(context.get("play_from") or ""), play_id, [])
+        except Exception as exc:
+            self.log(f"Atvp deferred share resolve failed: {exc}")
+            return original
+
+        if isinstance(result, str):
+            try:
+                result = json.loads(result)
+            except Exception:
+                return original
+        if not isinstance(result, dict):
+            return original
+
+        resolved = str(result.get("url") or "").strip()
+        if resolved.startswith(self.PUSH_PREFIX):
+            resolved = resolved[len(self.PUSH_PREFIX):].strip()
+        return self._decode_parse(resolved) or original
 
     def _encode_category_id(self, vod_id):
         return self.DETAIL_PREFIX + vod_id
@@ -970,9 +1001,13 @@ class Spider(HostSpider):
     def detailContent(self, ids):
         print('detailContent', ids)
         if isinstance(ids, (list, tuple)) and len(ids) == 1:
-            share_url = self._decode_parse(ids[0])
+            raw_id = str(ids[0] or "").strip()
+            share_url = self._decode_parse(raw_id)
             if share_url is not None:
-                return self._parse(share_url)
+                resolved_url = self._resolve_deferred_share_url(raw_id, share_url)
+                if resolved_url != share_url and share_url in self._detail_result_cache:
+                    self._detail_result_cache[resolved_url] = self._detail_result_cache[share_url]
+                return self._parse(resolved_url)
         result = self._require_inner().detailContent(ids)
         result = self._run_filters("detail", result, {"ids": ids})
         self._cache_detail_result(result)

--- a/src/test/java/cn/har01d/alist_tvbox/service/DoubanServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/DoubanServiceTest.java
@@ -1,13 +1,66 @@
 package cn.har01d.alist_tvbox.service;
 
+import cn.har01d.alist_tvbox.config.AppProperties;
+import cn.har01d.alist_tvbox.entity.AliasRepository;
+import cn.har01d.alist_tvbox.entity.MetaRepository;
 import cn.har01d.alist_tvbox.entity.Movie;
+import cn.har01d.alist_tvbox.entity.MovieRepository;
+import cn.har01d.alist_tvbox.entity.SettingRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.core.env.Environment;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class DoubanServiceTest {
+
+    @Mock
+    private AppProperties appProperties;
+    @Mock
+    private MetaRepository metaRepository;
+    @Mock
+    private MovieRepository movieRepository;
+    @Mock
+    private AliasRepository aliasRepository;
+    @Mock
+    private SettingRepository settingRepository;
+    @Mock
+    private SiteService siteService;
+    @Mock
+    private TaskService taskService;
+    @Mock
+    private FileDownloader fileDownloader;
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+    @Mock
+    private Environment environment;
+
+    private DoubanService doubanService;
+
+    @BeforeEach
+    void setUp() {
+        doubanService = new DoubanService(appProperties, metaRepository, movieRepository, aliasRepository,
+                settingRepository, siteService, taskService, fileDownloader, new RestTemplateBuilder(),
+                jdbcTemplate, environment);
+    }
 
     @Test
     void pickBestReturnsClosestYear() {
@@ -60,6 +113,54 @@ class DoubanServiceTest {
         assertThat(DoubanService.getYearFromText("1234")).isNull();
         assertThat(DoubanService.getYearFromText("没有年份的标题")).isNull();
         assertThat(DoubanService.getYearFromText(null)).isNull();
+    }
+
+    @Test
+    void isSeasonOnlyDetectsBareSeasonTokens() {
+        // Chinese season markers (from fixName transforming S01/S02 -> 第一季/第二季)
+        assertThat(DoubanService.isSeasonOnly("第一季")).isTrue();
+        assertThat(DoubanService.isSeasonOnly("第二季")).isTrue();
+        assertThat(DoubanService.isSeasonOnly("第十二季")).isTrue();
+        assertThat(DoubanService.isSeasonOnly("第3季")).isTrue();
+        // English / code forms (defensive)
+        assertThat(DoubanService.isSeasonOnly("Season 1")).isTrue();
+        assertThat(DoubanService.isSeasonOnly("S01")).isTrue();
+        assertThat(DoubanService.isSeasonOnly("SE01")).isTrue();
+        // real titles, even season-suffixed ones, are NOT bare season tokens
+        assertThat(DoubanService.isSeasonOnly("百花杀")).isFalse();
+        assertThat(DoubanService.isSeasonOnly("百花杀 第一季")).isFalse();
+        assertThat(DoubanService.isSeasonOnly("证言 第一季")).isFalse();
+        assertThat(DoubanService.isSeasonOnly("")).isFalse();
+        assertThat(DoubanService.isSeasonOnly(null)).isFalse();
+    }
+
+    // Regression: a season-only folder ("S01") must not match a random season-N show.
+    // Previously fixName("S01") -> "第一季", then LIKE '%第一季%' returned "证言 第一季".
+    @Test
+    void getByNameSkipsBroadMatchForBareSeasonToken() {
+        when(aliasRepository.findById(anyString())).thenReturn(Optional.empty());
+        when(movieRepository.getByName("第一季")).thenReturn(List.of());
+
+        assertThat(doubanService.getByName("S01", 2026)).isNull();
+        // the year-scoped name-contains fallback must never run for a bare season token
+        verify(movieRepository, never()).findByYearAndNameContains(anyInt(), anyString(), any());
+    }
+
+    // Regression: a dot-separated CJK folder ("百.花.杀（2026）") must resolve to the real
+    // title. Previously fixName -> "百 花 杀" never matched the stored "百花杀".
+    @Test
+    void getByNameCollapsesCjkSpacesSoDottedFolderMatches() {
+        Movie baihuasha = movie("百花杀", 2026);
+        baihuasha.setId(34815020);
+        when(aliasRepository.findById(anyString())).thenReturn(Optional.empty());
+        when(movieRepository.getByName("百花杀")).thenReturn(List.of());
+        when(movieRepository.findByYearAndNameContains(eq(2026), eq("百花杀"), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(baihuasha)));
+
+        Movie result = doubanService.getByName("百.花.杀（2026）", 2026);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo("百花杀");
     }
 
     private Movie movie(String name, Integer year) {

--- a/src/test/java/cn/har01d/alist_tvbox/service/TvBoxServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/TvBoxServiceTest.java
@@ -213,4 +213,83 @@ class TvBoxServiceTest {
         assertThat((String) result.get("url")).contains("/p/test-token/1@99");
         assertThat(result.get("type")).isEqualTo(DriverType.GUANGYA);
     }
+
+    // Regression for commit 22902e09 (#806): getPlaylist switched vod_id from
+    // encodeUrl(path) to a numeric proxy pid, so vod_id no longer ends with
+    // "playlist$1". The old name-recovery gate became dead code, leaving
+    // vod_name as the raw folder name (e.g. "S01") instead of the matched
+    // Douban title even when every other field (pic/actor/director/dbid) was set.
+    @Test
+    void getPlaylistShouldRenameVodNameToDoubanTitleForPlaylistPath() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/detail");
+        request.setScheme("http");
+        request.setServerName("127.0.0.1");
+        request.setServerPort(8080);
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        Site site = new Site();
+        site.setId(1);
+        site.setName("丫仙女");
+
+        String playlistPath = "/share/百.花.杀（2026）/S01/~playlist";
+        String folderPath = "/share/百.花.杀（2026）/S01";
+
+        FsDetail detail = new FsDetail();
+        detail.setName("S01");
+        detail.setModified("2026-07-24T17:59:07+08:00");
+
+        cn.har01d.alist_tvbox.entity.Movie movie = new cn.har01d.alist_tvbox.entity.Movie();
+        movie.setId(34815019);
+        movie.setName("百花杀");
+        movie.setYear(2026);
+        movie.setDbScore("8.6");
+
+        when(tenantService.valid(folderPath)).thenReturn(true);
+        when(aListService.getFile(site, folderPath)).thenReturn(detail);
+        when(proxyService.generatePath(site, playlistPath)).thenReturn(170885);
+        when(appProperties.isEnableHttps()).thenReturn(false);
+        when(doubanService.getByName(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.<Integer>any())).thenReturn(movie);
+        when(aListService.listFiles(site, folderPath, 1, 0)).thenReturn(new cn.har01d.alist_tvbox.model.FsResponse());
+
+        cn.har01d.alist_tvbox.tvbox.MovieList result = tvBoxService.getPlaylist("detail", site, playlistPath);
+
+        cn.har01d.alist_tvbox.tvbox.MovieDetail md = result.getList().get(0);
+        assertThat(md.getVod_name()).isEqualTo("百花杀");
+        assertThat(md.getDbid()).isEqualTo(34815019);
+    }
+
+    // When the show is not in the local Douban DB, the detail must still surface the
+    // show name derived from the parent folder instead of leaving the bare season token.
+    @Test
+    void getPlaylistFallsBackToCleanedParentNameWhenNoDoubanMatch() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/detail");
+        request.setScheme("http");
+        request.setServerName("127.0.0.1");
+        request.setServerPort(8080);
+        org.springframework.web.context.request.RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        Site site = new Site();
+        site.setId(1);
+        site.setName("丫仙女");
+
+        String playlistPath = "/share/百.花.杀（2026）/S01/~playlist";
+        String folderPath = "/share/百.花.杀（2026）/S01";
+
+        FsDetail detail = new FsDetail();
+        detail.setName("S01");
+        detail.setModified("2026-07-24T17:59:07+08:00");
+
+        when(tenantService.valid(folderPath)).thenReturn(true);
+        when(aListService.getFile(site, folderPath)).thenReturn(detail);
+        when(proxyService.generatePath(site, playlistPath)).thenReturn(170885);
+        when(appProperties.isEnableHttps()).thenReturn(false);
+        // no Douban match for any name (show not in local DB)
+        when(doubanService.getByName(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.<Integer>any())).thenReturn(null);
+        when(aListService.listFiles(site, folderPath, 1, 0)).thenReturn(new cn.har01d.alist_tvbox.model.FsResponse());
+
+        cn.har01d.alist_tvbox.tvbox.MovieList result = tvBoxService.getPlaylist("detail", site, playlistPath);
+
+        cn.har01d.alist_tvbox.tvbox.MovieDetail md = result.getList().get(0);
+        assertThat(md.getVod_name()).isEqualTo("百花杀");
+    }
 }

--- a/src/test/java/cn/har01d/alist_tvbox/util/TextUtilsTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/util/TextUtilsTest.java
@@ -67,6 +67,19 @@ class TextUtilsTest {
         log.info("{}", name);
     }
 
+    @Test
+    void collapseCjkSpacesJoinsDottedCjkNames() {
+        // fixName turns the anti-detection dots in "百.花.杀" into spaces; collapse them
+        // back so the real title "百花杀" (stored without spaces) can match.
+        assertEquals("百花杀", TextUtils.collapseCjkSpaces("百 花 杀"));
+        assertEquals("百花杀", TextUtils.collapseCjkSpaces("百花杀"));
+        // spaces between Latin words are preserved
+        assertEquals("Show Name", TextUtils.collapseCjkSpaces("Show Name"));
+        // only space between two Han characters is removed; Latin<->Han space is kept
+        assertEquals("X 战警", TextUtils.collapseCjkSpaces("X 战 警"));
+        assertNull(TextUtils.collapseCjkSpaces(null));
+    }
+
 
     @Test
     void loadShares() {


### PR DESCRIPTION
Folders like "百.花.杀（2026）/S01" left vod_name as the raw season token ("S01") or a wrong Douban match ("证言") due to four compounded defects:

1. getPlaylist's name-recovery gate checked vod_id.endsWith("playlist$1"), which has been dead since #806 switched vod_id to a numeric proxy pid. Re-key the gate on movieDetail.getPath().contains(PLAYLIST).
2. A bare season token (fixName turns "S01" into "第一季") reached the year-scoped LIKE fallback (LIKE '%第一季%') and matched an arbitrary season-N show of that year. Skip that fallback for season-only tokens via DoubanService.isSeasonOnly.
3. Dot-separated anti-detection CJK names ("百.花.杀") became "百 花 杀" via fixName and never matched the stored "百花杀". Add TextUtils.collapseCjkSpaces (applied in getByName and the display fallback), deliberately not folded into fixName so legitimate "重紫 第10季" / "name + ' 第一季'" spacing is preserved.
4. When no Douban entry exists for the show, fall back to the cleaned parent folder name instead of leaving the bare season token.