### PR TITLE
盘搜内置源支持单源配置覆盖全局

### DIFF
--- a/src/main/java/cn/har01d/alist_tvbox/service/RemoteSearchService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/RemoteSearchService.java
@@ -12,6 +12,7 @@ import cn.har01d.alist_tvbox.entity.TelegramChannelRepository;
 import cn.har01d.alist_tvbox.tvbox.MovieDetail;
 import cn.har01d.alist_tvbox.tvbox.MovieList;
 import cn.har01d.alist_tvbox.util.Utils;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -65,6 +66,7 @@ public class RemoteSearchService {
     private final ShareService shareService;
     private final TvBoxService tvBoxService;
     private final OfflineDownloadService offlineDownloadService;
+    private final SubscriptionSourceService subscriptionSourceService;
     private List<String> panSouDefaultChannels;
     private List<String> panSouBuiltinChannels;
     private String panSouToken;
@@ -85,7 +87,8 @@ public class RemoteSearchService {
                                TelegramChannelRepository telegramChannelRepository,
                                ShareService shareService,
                                TvBoxService tvBoxService,
-                               OfflineDownloadService offlineDownloadService) {
+                               OfflineDownloadService offlineDownloadService,
+                               SubscriptionSourceService subscriptionSourceService) {
         this.appProperties = appProperties;
         this.restTemplate = restTemplateBuilder.build();
         this.objectMapper = objectMapper;
@@ -93,6 +96,7 @@ public class RemoteSearchService {
         this.shareService = shareService;
         this.tvBoxService = tvBoxService;
         this.offlineDownloadService = offlineDownloadService;
+        this.subscriptionSourceService = subscriptionSourceService;
     }
 
     @PostConstruct
@@ -152,7 +156,7 @@ public class RemoteSearchService {
                 .map(TelegramChannel::getUsername)
                 .toList();
 
-        var messages = search(keyword, channels);
+        var messages = search(keyword, channels, "csp_FishPanSou");
         for (var message : messages) {
             list.add(toMovieDetail(message));
         }
@@ -194,7 +198,7 @@ public class RemoteSearchService {
                 .filter(TelegramChannel::isValid)
                 .map(TelegramChannel::getUsername)
                 .toList();
-        List<Message> messages = search(keyword, channels);
+        List<Message> messages = search(keyword, channels, "csp_FishPanSouGroup");
         String cacheId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
         groupCache.put(cacheId, messages);
 
@@ -284,8 +288,56 @@ public class RemoteSearchService {
         return tvBoxService.getDetail("", "1$" + path + "/~playlist", title, 0);
     }
 
+    // Per-built-in-source override parsed from the builtin extend JSON
+    // ({"source":..,"filter_include":..,"filter_exclude":..}); null when no siteKey
+    // or no extend configured, so callers fall back to global AppProperties values.
+    private JsonNode pansouSourceConfig(String siteKey) {
+        if (siteKey == null) {
+            return null;
+        }
+        String extend = subscriptionSourceService.getBuiltinExtend(siteKey);
+        if (StringUtils.isBlank(extend)) {
+            return null;
+        }
+        try {
+            JsonNode node = objectMapper.readTree(extend);
+            return node.isObject() ? node : null;
+        } catch (Exception e) {
+            log.debug("invalid pansou source extend for {}: {}", siteKey, extend);
+            return null;
+        }
+    }
+
+    private String resolvePanSouSource(JsonNode config) {
+        String override = config == null ? "" : config.path("source").asText("");
+        return StringUtils.isNotBlank(override) ? override : appProperties.getPanSouSource();
+    }
+
+    private List<String> resolvePanSouFilterInclude(JsonNode config) {
+        return resolvePanSouFilter(config, "filter_include", appProperties.getPanSouFilterInclude());
+    }
+
+    private List<String> resolvePanSouFilterExclude(JsonNode config) {
+        return resolvePanSouFilter(config, "filter_exclude", appProperties.getPanSouFilterExclude());
+    }
+
+    // per-field inherit: a non-blank override wins, otherwise fall back to the global value
+    private List<String> resolvePanSouFilter(JsonNode config, String field, List<String> globalValue) {
+        String csv = config == null ? "" : config.path(field).asText("");
+        if (StringUtils.isBlank(csv)) {
+            return globalValue;
+        }
+        return Arrays.stream(csv.split(",")).map(String::trim)
+                .filter(StringUtils::isNotBlank).toList();
+    }
+
     public List<Message> search(String keyword, List<String> channels) {
-        var request = new SearchRequest(keyword, getSearchChannels(channels), appProperties.getPanSouSource());
+        return search(keyword, channels, null);
+    }
+
+    public List<Message> search(String keyword, List<String> channels, String siteKey) {
+        JsonNode sourceConfig = pansouSourceConfig(siteKey);
+        var request = new SearchRequest(keyword, getSearchChannels(channels), resolvePanSouSource(sourceConfig));
         request.setExt(Map.of("referer", "https://dm.xueximeng.com"));
         boolean offlineDownloadEnabled = offlineDownloadService.getConfig().enabled();
         if (StringUtils.isNotBlank(keyword)) {
@@ -301,8 +353,8 @@ public class RemoteSearchService {
             request.setRefresh(true);
         }
         //request.setRes(StringUtils.defaultIfBlank(appProperties.getPanSouRes(), "merge"));
-        List<String> filterInclude = appProperties.getPanSouFilterInclude();
-        List<String> filterExclude = appProperties.getPanSouFilterExclude();
+        List<String> filterInclude = resolvePanSouFilterInclude(sourceConfig);
+        List<String> filterExclude = resolvePanSouFilterExclude(sourceConfig);
         if (!CollectionUtils.isEmpty(filterInclude) || !CollectionUtils.isEmpty(filterExclude)) {
             request.setFilter(new SearchRequest.Filter(
                     CollectionUtils.isEmpty(filterInclude) ? List.of() : filterInclude,

--- a/src/main/java/cn/har01d/alist_tvbox/service/SubscriptionSourceService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/SubscriptionSourceService.java
@@ -29,7 +29,8 @@ import java.util.Set;
 public class SubscriptionSourceService {
     private static final String BUILTIN_SETTINGS_KEY = "builtin_subscription_sources";
     private static final String SORT_ORDER_MIGRATED_KEY = "subscription_source_sort_order_migrated";
-    private static final Set<String> EXTENDABLE_BUILTINS = Set.of("csp_PianDan");
+    private static final Set<String> EXTENDABLE_BUILTINS =
+            Set.of("csp_PianDan", "csp_FishPanSou", "csp_FishPanSouGroup");
 
     private final AppProperties appProperties;
     private final PluginRepository pluginRepository;

--- a/src/test/java/cn/har01d/alist_tvbox/service/RemoteSearchServiceTest.java
+++ b/src/test/java/cn/har01d/alist_tvbox/service/RemoteSearchServiceTest.java
@@ -48,7 +48,8 @@ class RemoteSearchServiceTest {
                 mock(TelegramChannelRepository.class),
                 mock(ShareService.class),
                 mock(TvBoxService.class),
-                offlineDownloadService
+                offlineDownloadService,
+                mock(SubscriptionSourceService.class)
         );
 
         server.expect(once(), requestTo("http://pansou.example/api/health"))
@@ -87,7 +88,7 @@ class RemoteSearchServiceTest {
         RemoteSearchService service = new RemoteSearchService(
                 appProperties, restTemplateBuilder(restTemplate), objectMapper,
                 mock(TelegramChannelRepository.class), mock(ShareService.class),
-                mock(TvBoxService.class), offlineDownloadService);
+                mock(TvBoxService.class), offlineDownloadService, mock(SubscriptionSourceService.class));
 
         server.expect(once(), requestTo("http://pansou.example/api/health"))
                 .andRespond(withSuccess("""
@@ -130,7 +131,8 @@ class RemoteSearchServiceTest {
                 telegramChannelRepository,
                 shareService,
                 tvBoxService,
-                offlineDownloadService
+                offlineDownloadService,
+                mock(SubscriptionSourceService.class)
         );
 
         server.expect(once(), requestTo("http://pansou.example/api/search"))
@@ -168,7 +170,8 @@ class RemoteSearchServiceTest {
                 mock(TelegramChannelRepository.class),
                 mock(ShareService.class),
                 mock(TvBoxService.class),
-                mock(OfflineDownloadService.class)
+                mock(OfflineDownloadService.class),
+                mock(SubscriptionSourceService.class)
         );
 
         server.expect(once(), requestTo("http://pansou.example/api/health"))
@@ -189,7 +192,7 @@ class RemoteSearchServiceTest {
         RemoteSearchService service = new RemoteSearchService(
                 appProperties, restTemplateBuilder(new RestTemplate()), objectMapper,
                 mock(TelegramChannelRepository.class), mock(ShareService.class),
-                mock(TvBoxService.class), mock(OfflineDownloadService.class));
+                mock(TvBoxService.class), mock(OfflineDownloadService.class), mock(SubscriptionSourceService.class));
 
         // Only quark selected -> baidu (unselected) and pikpak (not in supported 9) are NOT checkable.
         List<Message> checkable = service.selectCheckable(List.of(
@@ -207,7 +210,7 @@ class RemoteSearchServiceTest {
         RemoteSearchService service = new RemoteSearchService(
                 appProperties, restTemplateBuilder(new RestTemplate()), objectMapper,
                 mock(TelegramChannelRepository.class), mock(ShareService.class),
-                mock(TvBoxService.class), mock(OfflineDownloadService.class));
+                mock(TvBoxService.class), mock(OfflineDownloadService.class), mock(SubscriptionSourceService.class));
 
         // Unset -> all supported types checkable; pikpak (not supported) still excluded.
         List<Message> checkable = service.selectCheckable(List.of(
@@ -234,7 +237,7 @@ class RemoteSearchServiceTest {
         RemoteSearchService service = new RemoteSearchService(
                 appProperties, restTemplateBuilder(restTemplate), objectMapper,
                 telegramChannelRepository, mock(ShareService.class),
-                mock(TvBoxService.class), offlineDownloadService);
+                mock(TvBoxService.class), offlineDownloadService, mock(SubscriptionSourceService.class));
 
         server.expect(once(), requestTo("http://pansou.example/api/search"))
                 .andRespond(withSuccess("""
@@ -269,6 +272,72 @@ class RemoteSearchServiceTest {
         } finally {
             RequestContextHolder.resetRequestAttributes();
         }
+    }
+
+    @Test
+    void perSourceOverrideWinsOverGlobal() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        AppProperties appProperties = new AppProperties();
+        appProperties.setPanSouUrl("http://pansou.example");
+        appProperties.setPanSouSource("all");
+        OfflineDownloadService offlineDownloadService = mock(OfflineDownloadService.class);
+        when(offlineDownloadService.getConfig()).thenReturn(new OfflineDownloadConfigDto(false, "", null, ""));
+        SubscriptionSourceService subscriptionSourceService = mock(SubscriptionSourceService.class);
+        when(subscriptionSourceService.getBuiltinExtend("csp_FishPanSou"))
+                .thenReturn("{\"source\":\"tg\",\"filter_include\":\"1080, 4K\",\"filter_exclude\":\"枪版\"}");
+
+        RemoteSearchService service = new RemoteSearchService(
+                appProperties, restTemplateBuilder(restTemplate), objectMapper,
+                mock(TelegramChannelRepository.class), mock(ShareService.class),
+                mock(TvBoxService.class), offlineDownloadService, subscriptionSourceService);
+
+        server.expect(once(), requestTo("http://pansou.example/api/search"))
+                .andExpect(content().json("""
+                        {"kw":"movie","src":"tg","filter":{"include":["1080","4K"],"exclude":["枪版"]}}
+                        """))
+                .andRespond(withSuccess("""
+                        {"code":0,"message":"ok","data":{"total":0,"results":[],"merged_by_type":{}}}
+                        """, org.springframework.http.MediaType.APPLICATION_JSON));
+
+        // 鱼佬盘搜 path: per-source override (source/包含词/排除词) all win over global
+        service.search("movie", List.of(), "csp_FishPanSou");
+
+        server.verify();
+    }
+
+    @Test
+    void perSourceBlankFieldsFallBackToGlobal() {
+        RestTemplate restTemplate = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        AppProperties appProperties = new AppProperties();
+        appProperties.setPanSouUrl("http://pansou.example");
+        appProperties.setPanSouSource("all");
+        appProperties.setPanSouFilterInclude(List.of("1080"));
+        appProperties.setPanSouFilterExclude(List.of("枪版"));
+        OfflineDownloadService offlineDownloadService = mock(OfflineDownloadService.class);
+        when(offlineDownloadService.getConfig()).thenReturn(new OfflineDownloadConfigDto(false, "", null, ""));
+        SubscriptionSourceService subscriptionSourceService = mock(SubscriptionSourceService.class);
+        when(subscriptionSourceService.getBuiltinExtend("csp_FishPanSou"))
+                .thenReturn("{\"source\":\"tg\"}");
+
+        RemoteSearchService service = new RemoteSearchService(
+                appProperties, restTemplateBuilder(restTemplate), objectMapper,
+                mock(TelegramChannelRepository.class), mock(ShareService.class),
+                mock(TvBoxService.class), offlineDownloadService, subscriptionSourceService);
+
+        server.expect(once(), requestTo("http://pansou.example/api/search"))
+                .andExpect(content().json("""
+                        {"kw":"movie","src":"tg","filter":{"include":["1080"],"exclude":["枪版"]}}
+                        """))
+                .andRespond(withSuccess("""
+                        {"code":0,"message":"ok","data":{"total":0,"results":[],"merged_by_type":{}}}
+                        """, org.springframework.http.MediaType.APPLICATION_JSON));
+
+        // only source overridden; 包含词/排除词 inherit global
+        service.search("movie", List.of(), "csp_FishPanSou");
+
+        server.verify();
     }
 
     private static Message message(String type, String link) {

--- a/web-ui/src/views/SubscriptionsView.vue
+++ b/web-ui/src/views/SubscriptionsView.vue
@@ -620,6 +620,29 @@
       </template>
     </el-dialog>
 
+    <el-dialog v-model="panSouSourceVisible" :title="panSouSourceTitle" width="480px">
+      <el-form label-width="90px">
+        <el-form-item label="数据源">
+          <el-radio-group v-model="panSouSourceValue">
+            <el-radio v-for="item in panSouSourceOptions" :key="item.value" :value="item.value">{{ item.label }}</el-radio>
+          </el-radio-group>
+          <div class="ext-tip">选择「继承全局」则使用 PanSou 全局数据源设置。</div>
+        </el-form-item>
+        <el-form-item label="包含词">
+          <el-input v-model="panSouFilterInclude" placeholder="多个用逗号分隔，如 1080,4K；留空继承全局"/>
+        </el-form-item>
+        <el-form-item label="排除词">
+          <el-input v-model="panSouFilterExclude" placeholder="多个用逗号分隔，如 枪版,广告；留空继承全局"/>
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <span class="dialog-footer">
+          <el-button @click="panSouSourceVisible = false">取消</el-button>
+          <el-button type="primary" @click="savePanSouSource">保存</el-button>
+        </span>
+      </template>
+    </el-dialog>
+
     <el-dialog v-model="pluginFilterVisible" title="过滤器管理" fullscreen>
       <el-form :inline="true" :model="pluginFilterForm">
         <el-form-item label="过滤器地址" required>
@@ -1239,6 +1262,18 @@ const pianDanHomeOptions = [
   {label: '国内口碑综艺榜', value: 'show_chinese_best_weekly'}
 ]
 const pianDanHomeValues = new Set(pianDanHomeOptions.map(item => item.value))
+const panSouSourceVisible = ref(false)
+const panSouSourceTarget = ref<ManagedSource | null>(null)
+const panSouSourceValue = ref('')
+const panSouFilterInclude = ref('')
+const panSouFilterExclude = ref('')
+const panSouSourceTitle = computed(() => (panSouSourceTarget.value?.name || '盘搜') + ' · 设置')
+const panSouSourceOptions = [
+  {label: '继承全局', value: ''},
+  {label: '全部', value: 'all'},
+  {label: '电报', value: 'tg'},
+  {label: '插件', value: 'plugin'}
+]
 const pluginFilterForm = ref<PluginFilter>({
   id: 0,
   name: '',
@@ -2574,6 +2609,8 @@ const saveSourceExtend = () => {
 const openSourceConfig = (source: ManagedSource) => {
   if (source.builtin && source.key === 'csp_PianDan') {
     openPianDanHomeDialog(source)
+  } else if (source.builtin && (source.key === 'csp_FishPanSou' || source.key === 'csp_FishPanSouGroup')) {
+    openPanSouSourceDialog(source)
   } else {
     openSourceExtendDialog(source)
   }
@@ -2608,6 +2645,43 @@ const savePianDanHome = () => {
   pianDanHomeTarget.value.extend = JSON.stringify({home: pianDanHomeValue.value, mode: pianDanMode.value})
   updateSource(pianDanHomeTarget.value)
   pianDanHomeVisible.value = false
+}
+
+const openPanSouSourceDialog = (source: ManagedSource) => {
+  panSouSourceTarget.value = source
+  let sourceValue = ''
+  let include = ''
+  let exclude = ''
+  try {
+    const parsed = source.extend ? JSON.parse(source.extend) : null
+    if (parsed && typeof parsed === 'object') {
+      sourceValue = typeof parsed.source === 'string' ? parsed.source : ''
+      include = typeof parsed.filter_include === 'string' ? parsed.filter_include : ''
+      exclude = typeof parsed.filter_exclude === 'string' ? parsed.filter_exclude : ''
+    }
+  } catch {
+    sourceValue = ''
+  }
+  panSouSourceValue.value = sourceValue
+  panSouFilterInclude.value = include
+  panSouFilterExclude.value = exclude
+  panSouSourceVisible.value = true
+}
+
+const savePanSouSource = () => {
+  if (!panSouSourceTarget.value) {
+    return
+  }
+  const config: Record<string, string> = {
+    source: panSouSourceValue.value,
+    filter_include: panSouFilterInclude.value,
+    filter_exclude: panSouFilterExclude.value
+  }
+  // drop blank fields so they inherit the global config
+  const payload = Object.fromEntries(Object.entries(config).filter(([, v]) => v !== ''))
+  panSouSourceTarget.value.extend = Object.keys(payload).length ? JSON.stringify(payload) : ''
+  updateSource(panSouSourceTarget.value)
+  panSouSourceVisible.value = false
 }
 
 const updatePluginFilter = (filter: PluginFilter) => {


### PR DESCRIPTION
鱼佬盘搜(csp_FishPanSou)与盘搜•分组(csp_FishPanSouGroup)复用片单导航的 extend 机制，可各自覆盖全局盘搜的数据源/包含词/排除词，逐字段继承(非空覆盖，
否则回落全局)；/tgsp 不受影响。

- SubscriptionSourceService: EXTENDABLE_BUILTINS 加入两个盘搜源
- RemoteSearchService: 注入 SubscriptionSourceService，search 三参重载按源 解析 override；pansou/pansouGroup 路由到各自 siteKey
- 前端: 订阅源管理新增盘搜配置对话框(数据源/包含词/排除词)
- 测试: 覆盖优先 + 空字段回落全局