### PR TITLE
静态文件上传 .py 自动注册为订阅源

### DIFF
--- a/src/main/java/cn/har01d/alist_tvbox/entity/PluginRepository.java
+++ b/src/main/java/cn/har01d/alist_tvbox/entity/PluginRepository.java
@@ -13,4 +13,7 @@ public interface PluginRepository extends JpaRepository<Plugin, Integer> {
     List<Plugin> findAllByOrderBySortOrderAscIdAsc();
 
     List<Plugin> findByEnabledTrueOrderBySortOrderAscIdAsc();
+
+    // 文件-backed 插件：url 以 /static/plugins/ 开头，用于目录双向同步
+    List<Plugin> findByUrlStartingWithOrderBySortOrderAscIdAsc(String prefix);
 }

--- a/src/main/java/cn/har01d/alist_tvbox/service/PluginFileSyncService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/PluginFileSyncService.java
@@ -1,0 +1,108 @@
+package cn.har01d.alist_tvbox.service;
+
+import cn.har01d.alist_tvbox.entity.Plugin;
+import cn.har01d.alist_tvbox.entity.PluginRepository;
+import cn.har01d.alist_tvbox.util.Utils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * 静态文件目录与订阅源（Spider Plugin）的双向同步。
+ * <p>
+ * 静态目录 {@code static/plugins/} 下的 {@code .py} 文件会自动注册为订阅源：
+ * url 形如 {@code /static/plugins/<相对路径>.py} 作为唯一身份，文件删除后对应插件一并删除。
+ * 远程导入的插件 url 不带该前缀，永不受影响。所有写操作后调用 {@link #reconcile()} 幂等收敛。
+ */
+@Slf4j
+@Service
+public class PluginFileSyncService {
+
+    private final PluginService pluginService;
+    private final PluginRepository pluginRepository;
+
+    public PluginFileSyncService(PluginService pluginService, PluginRepository pluginRepository) {
+        this.pluginService = pluginService;
+        this.pluginRepository = pluginRepository;
+    }
+
+    /**
+     * 重扫 static/plugins/ 下的 .py 文件，upsert 对应插件，并删除文件已不存在的 file-backed 插件。
+     * 幂等，可安全重复调用。
+     */
+    public synchronized void reconcile() {
+        Path base = Utils.getWebPath("static");
+        Path dir = base.resolve(PluginService.FILE_PLUGIN_DIR);
+        // 自动创建 plugins 目录，确保静态文件页面可见、可直接上传
+        try {
+            Files.createDirectories(dir);
+        } catch (IOException e) {
+            log.warn("failed to create plugins dir: {}", dir, e);
+        }
+
+        List<Plugin> existing = pluginRepository.findByUrlStartingWithOrderBySortOrderAscIdAsc(PluginService.FILE_PLUGIN_URL_PREFIX);
+        if (!Files.exists(dir)) {
+            // 目录创建失败：无法提供文件，移除残留的 file-backed 插件
+            log.debug("plugins dir unavailable, removing {} file-backed plugins", existing.size());
+            existing.forEach(this::deleteQuietly);
+            return;
+        }
+
+        Set<String> presentUrls = new HashSet<>();
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().toLowerCase().endsWith(".py"))
+                    .forEach(file -> {
+                        String url = toStaticUrl(base, file);
+                        try {
+                            String body = Files.readString(file);
+                            pluginService.upsertFromContent(url, body);
+                            presentUrls.add(url);
+                        } catch (Exception e) {
+                            log.warn("failed to register plugin file {}: {}", file, e.getMessage());
+                        }
+                    });
+        } catch (IOException e) {
+            log.warn("failed to walk plugins dir: {}", dir, e);
+            return;
+        }
+
+        for (Plugin plugin : existing) {
+            if (!presentUrls.contains(plugin.getUrl())) {
+                deleteQuietly(plugin);
+            }
+        }
+        log.debug("plugin file sync reconciled: {} present", presentUrls.size());
+    }
+
+    private String toStaticUrl(Path base, Path file) {
+        String relative = base.relativize(file).toString().replace('\\', '/');
+        return PluginService.STATIC_URL_PREFIX + relative;
+    }
+
+    private void deleteQuietly(Plugin plugin) {
+        try {
+            pluginService.delete(plugin.getId());
+        } catch (Exception e) {
+            log.warn("failed to delete stale plugin {}: {}", plugin.getUrl(), e.getMessage());
+        }
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        try {
+            reconcile();
+        } catch (Exception e) {
+            log.warn("startup plugin file reconcile failed", e);
+        }
+    }
+}

--- a/src/main/java/cn/har01d/alist_tvbox/service/PluginService.java
+++ b/src/main/java/cn/har01d/alist_tvbox/service/PluginService.java
@@ -16,10 +16,13 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -38,6 +41,11 @@ public class PluginService {
     private static final Pattern PLUGIN_VERSION = Pattern.compile("(?m)^\\s*//@version:(\\d+)\\s*$");
     private static final Pattern PLUGIN_NAME = Pattern.compile("(?m)^\\s*//@name:(.+)\\s*$");
     private static final String GITHUB_PROXY = "github_proxy";
+
+    // 文件-backed 插件：url 形如 /static/plugins/<相对路径>.py，由静态文件目录双向同步管理
+    public static final String STATIC_URL_PREFIX = "/static/";
+    public static final String FILE_PLUGIN_DIR = "plugins";
+    public static final String FILE_PLUGIN_URL_PREFIX = STATIC_URL_PREFIX + FILE_PLUGIN_DIR + "/";
 
     private final PluginRepository pluginRepository;
     private final SettingRepository settingRepository;
@@ -103,6 +111,43 @@ public class PluginService {
         return pluginRepository.save(plugin);
     }
 
+    /**
+     * 静态文件目录双向同步入口：按 url 严格匹配 upsert，不发起 HTTP 下载。
+     * externalId 与现有不同 url 的插件冲突时丢弃，避免中断 reconcile。
+     */
+    @Transactional
+    public Plugin upsertFromContent(String url, String body) {
+        String name = extractPluginName(body);
+        if (StringUtils.isBlank(name)) {
+            name = deriveSourceName(url);
+        }
+        DownloadedPlugin downloaded = new DownloadedPlugin(body, name, extractPluginId(body), extractPluginVersion(body));
+
+        Plugin existing = pluginRepository.findByUrl(url).orElse(null);
+        if (existing != null) {
+            applyDownloadedPlugin(existing, downloaded, null, shouldUpdateName(existing));
+            existing.setLastCheckedAt(OffsetDateTime.now());
+            existing.setLastError("");
+            return pluginRepository.save(existing);
+        }
+
+        Plugin plugin = new Plugin();
+        plugin.setUrl(url);
+        applyDownloadedPlugin(plugin, downloaded, null, false);
+        if (StringUtils.isNotBlank(plugin.getExternalId())
+                && pluginRepository.findByExternalId(plugin.getExternalId())
+                        .filter(other -> !url.equals(other.getUrl()))
+                        .isPresent()) {
+            log.warn("externalId [{}] 与现有插件冲突，文件-backed 插件 [{}] 丢弃 externalId", plugin.getExternalId(), url);
+            plugin.setExternalId(null);
+        }
+        plugin.setEnabled(true);
+        plugin.setSortOrder(subscriptionSourceService.nextSortOrder());
+        plugin.setLastCheckedAt(OffsetDateTime.now());
+        plugin.setLastError("");
+        return pluginRepository.save(plugin);
+    }
+
     @Transactional
     public Plugin update(Integer id, Plugin input) {
         Plugin plugin = pluginRepository.findById(id).orElseThrow(NotFoundException::new);
@@ -124,6 +169,10 @@ public class PluginService {
     @Transactional
     public Plugin refresh(Integer id) {
         Plugin plugin = pluginRepository.findById(id).orElseThrow(NotFoundException::new);
+        // 文件-backed 插件直接从磁盘读取，不发起 HTTP 下载
+        if (StringUtils.startsWith(plugin.getUrl(), FILE_PLUGIN_URL_PREFIX)) {
+            return refresh(plugin, readFileBackedPlugin(plugin));
+        }
         return refresh(plugin, null);
     }
 
@@ -475,6 +524,25 @@ public class PluginService {
      */
     private boolean isValidUrl(String url) {
         return Utils.isSafeExternalUrl(url);
+    }
+
+    private DownloadedPlugin readFileBackedPlugin(Plugin plugin) {
+        String body = readFileBackedContent(plugin.getUrl());
+        String name = extractPluginName(body);
+        if (StringUtils.isBlank(name)) {
+            name = deriveSourceName(plugin.getUrl());
+        }
+        return new DownloadedPlugin(body, name, extractPluginId(body), extractPluginVersion(body));
+    }
+
+    private String readFileBackedContent(String url) {
+        String relative = StringUtils.removeStart(url, STATIC_URL_PREFIX);
+        Path file = Utils.getWebPath("static").resolve(relative).normalize();
+        try {
+            return Files.readString(file);
+        } catch (IOException e) {
+            throw new BadRequestException("插件文件读取失败: " + file, e);
+        }
     }
 
     public String readContent(Integer id) {

--- a/src/main/java/cn/har01d/alist_tvbox/web/PluginController.java
+++ b/src/main/java/cn/har01d/alist_tvbox/web/PluginController.java
@@ -1,6 +1,7 @@
 package cn.har01d.alist_tvbox.web;
 
 import cn.har01d.alist_tvbox.entity.Plugin;
+import cn.har01d.alist_tvbox.service.PluginFileSyncService;
 import cn.har01d.alist_tvbox.service.PluginService;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,6 +19,7 @@ import java.util.List;
 @RequestMapping("/api/plugins")
 public class PluginController {
     private final PluginService pluginService;
+    private final PluginFileSyncService pluginFileSyncService;
 
     private record PluginImportRequest(String url) {
     }
@@ -25,8 +27,9 @@ public class PluginController {
     private record PluginBatchDeleteRequest(List<Integer> ids) {
     }
 
-    public PluginController(PluginService pluginService) {
+    public PluginController(PluginService pluginService, PluginFileSyncService pluginFileSyncService) {
         this.pluginService = pluginService;
+        this.pluginFileSyncService = pluginFileSyncService;
     }
 
     @GetMapping
@@ -54,6 +57,11 @@ public class PluginController {
     @PostMapping("/{id}/refresh")
     public Plugin refresh(@PathVariable Integer id) {
         return pluginService.refresh(id);
+    }
+
+    @PostMapping("/scan")
+    public void scan() {
+        pluginFileSyncService.reconcile();
     }
 
     @PostMapping("/reorder")

--- a/src/main/java/cn/har01d/alist_tvbox/web/StaticFileController.java
+++ b/src/main/java/cn/har01d/alist_tvbox/web/StaticFileController.java
@@ -2,6 +2,7 @@ package cn.har01d.alist_tvbox.web;
 
 import cn.har01d.alist_tvbox.dto.StaticFileInfo;
 import cn.har01d.alist_tvbox.exception.BadRequestException;
+import cn.har01d.alist_tvbox.service.PluginFileSyncService;
 import cn.har01d.alist_tvbox.util.Utils;
 import lombok.extern.slf4j.Slf4j;
 import jakarta.servlet.http.HttpServletResponse;
@@ -39,6 +40,29 @@ import java.util.zip.ZipOutputStream;
 public class StaticFileController {
 
     private static final String URL_PREFIX = "/static/";
+    private static final String PLUGINS_DIR = "plugins";
+
+    private final PluginFileSyncService pluginFileSyncService;
+
+    public StaticFileController(PluginFileSyncService pluginFileSyncService) {
+        this.pluginFileSyncService = pluginFileSyncService;
+    }
+
+    /** 路径是否落在 plugins/ 目录下（相对 static 根）。 */
+    private static boolean underPlugins(String path) {
+        return path != null && !path.isEmpty()
+                && (path.equals(PLUGINS_DIR) || path.startsWith(PLUGINS_DIR + "/"));
+    }
+
+    private void maybeSyncPlugins(boolean touched) {
+        if (touched) {
+            try {
+                pluginFileSyncService.reconcile();
+            } catch (Exception e) {
+                log.warn("plugin file sync failed", e);
+            }
+        }
+    }
 
     @GetMapping
     public List<StaticFileInfo> list(@RequestParam(defaultValue = "") String dir) throws IOException {
@@ -132,6 +156,8 @@ public class StaticFileController {
             file.transferTo(filePath.toFile());
             log.info("uploaded file: {}", filePath);
         }
+
+        maybeSyncPlugins(underPlugins(dir) || extract);
     }
 
     @DeleteMapping
@@ -159,6 +185,7 @@ public class StaticFileController {
             Files.delete(targetPath);
         }
         log.info("deleted: {}", targetPath);
+        maybeSyncPlugins(underPlugins(path));
     }
 
     @PostMapping("/rename")
@@ -185,6 +212,7 @@ public class StaticFileController {
 
         Files.move(targetPath, newPath);
         log.info("renamed {} -> {}", targetPath, newPath);
+        maybeSyncPlugins(underPlugins(path));
     }
 
     @DeleteMapping("/batch")
@@ -219,6 +247,7 @@ public class StaticFileController {
             log.info("deleted: {}", targetPath);
             count++;
         }
+        maybeSyncPlugins(paths.stream().anyMatch(StaticFileController::underPlugins));
         return count;
     }
 
@@ -326,6 +355,7 @@ public class StaticFileController {
             log.info("moved {} -> {}", srcPath, newPath);
             count++;
         }
+        maybeSyncPlugins(paths.stream().anyMatch(StaticFileController::underPlugins) || underPlugins(targetDir));
         return count;
     }
 

--- a/web-ui/src/views/FilesView.vue
+++ b/web-ui/src/views/FilesView.vue
@@ -61,6 +61,7 @@
               <el-button @click="loadStatic">刷新</el-button>
               <el-button type="success" @click="showUploadDialog">上传文件</el-button>
               <el-button type="primary" @click="showMkdirDialog">新建文件夹</el-button>
+              <el-button type="warning" @click="scanPlugins">扫描插件目录</el-button>
             </template>
           </div>
         </el-row>
@@ -73,6 +74,16 @@
               <a :href="currentUrl+'/wallpaper'+token" target="_blank">{{ currentUrl }}/wallpaper{{ token }}</a><br>
               订阅定制，壁纸地址填写：
               <code>WALLPAPER_API</code><br>
+            </p>
+          </template>
+        </el-alert>
+
+        <el-alert type="success" :closable="false" show-icon style="margin-bottom: 10px">
+          <template #title>
+            <p>
+              将 <code>.py</code> 爬虫脚本上传到 <strong>plugins</strong> 文件夹，会自动同步到<strong>订阅源管理</strong>：
+              上传/重传即注册或更新，删除文件即移除（也可
+              <a href="javascript:void(0)" style="color: var(--el-color-success)" @click="scanPlugins">手动扫描</a>）。
             </p>
           </template>
         </el-alert>
@@ -445,6 +456,10 @@ const showUploadDialog = () => {
 
 const handleUploadSuccess = () => {
   ElMessage.success('上传成功')
+  const dir = currentStaticDir.value || ''
+  if (dir === 'plugins' || dir.startsWith('plugins/')) {
+    ElMessage.info('已同步到订阅源管理')
+  }
   uploadDialogVisible.value = false
   uploadRef.value?.clearFiles()
   loadStatic()
@@ -452,6 +467,14 @@ const handleUploadSuccess = () => {
 
 const handleUploadError = () => {
   ElMessage.error('上传失败')
+}
+
+const scanPlugins = () => {
+  axios.post('/api/plugins/scan').then(() => {
+    ElMessage.success('已扫描 plugins 目录并同步订阅源')
+  }).catch(() => {
+    ElMessage.error('扫描失败')
+  })
 }
 
 const showMkdirDialog = () => {


### PR DESCRIPTION
- 新增 PluginFileSyncService：扫描 static/plugins/ 下 .py，按 url 前缀 /static/plugins/ 幂等 upsert/删除 Spider 插件，启动时同步并自动创建目录
- PluginService: upsertFromContent 按 url 严格匹配、不走 HTTP 下载； 文件-backed 插件刷新改为从磁盘读取
- StaticFileController: 上传/删除/批量删除/重命名/移动后触发 reconcile
- 新增 POST /api/plugins/scan 手动扫描
- 前端：plugins/ 自动同步提示、扫描插件目录按钮、上传到 plugins/ 提示